### PR TITLE
Add Title to ridley_articles_dashboard by merging Ridley_bibliography

### DIFF
--- a/data/processed/ridley_articles_dashboard.csv
+++ b/data/processed/ridley_articles_dashboard.csv
@@ -1,1070 +1,1072 @@
-ArticleID,Authors,Year,Study_design,Ecoregion,Spatial_Scale,Spatial_res,Continent_Ocean,country_eez
-25370,Rímalová_etal,2014,Observational,Freshwater,National,,europe,Czech Republic
-23013,Abade_etal,2018,Observational,Terrestrial,Local,,africa,Tanzania
-23018,Abrahms_etal,2019,Observational,Marine,Local,0.1,north pacific,United States
-23019,Abram_etal,2015,Observational,Terrestrial,Local,1,asia,Indonesia
-23020,Abreo_etal,2019,Observational,Marine,Sub-national,,south china sea,Philippines
-23022,Acevedo_etal,2007,Observational,Terrestrial,Sub-national,1,europe,Spain
-23030,Adams and Setterfield,2015,Observational,Terrestrial,Sub-national,250,australasia,Australia
-23046,Ahmad_etal,2015,Observational,Terrestrial,Local,,asia,India
-23047,Ahmadi_etal,2019,Observational,Terrestrial,Multi-national,1,asia,Azerbaijan
-23061,Albouy_etal,2017,Observational,Marine,Global,1,Unknown,Unknown
-23062,Albright_etal,2017,Observational,Terrestrial,Sub-national,0.125,north america,United States
-23063,Alcaraz_etal,2015,Observational,Freshwater,Sub-national,10,europe,Spain
-23051,Al-Chokhachy_etal,2014,Observational,Freshwater,Local,,north america,Canada
-23064,Alexander and Waters,2000,Observational,Terrestrial,Local,,north america,Canada
-23068,Alfred_etal,2010,Observational,Terrestrial,Sub-national,2.5,asia,Malaysia
-23071,Allan_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown
-23072,Allan_etal,2019,Observational,Terrestrial,Global,30,Unknown,Unknown
-23073,Almeida_etal,2014,Observational,Freshwater,Sub-national,10,europe,United Kingdom
-23074,Almodóvar_etal,2012,Observational,Freshwater,Local,,europe,Spain
-23052,Al-Nasrawi_etal,2018,Observational,Terrestrial,Local,0.8,australasia,Australia
-23080,Álvarez,2003,Observational,Terrestrial,National,,south america,Colombia
-23082,Alvarez-Berastegui_etal,2014,Observational,Marine,Sub-national,300,mediterranean,Spain
-23083,Alvarez-Berrios and Mitchell,2015,Observational,Terrestrial,Multi-national,250,south america,Brazil
-23085,Alvarez-Filip_etal,2019,Observational,Marine,Sub-national,,north atlantic,Mexico
-23086,Alvarez-Romero_etal,2013,Observational,Marine,Sub-national,500,south pacific,Australia
-23087,Alves_etal,2014,Observational,Terrestrial,Multi-national,0.16,north america,Canada
-25335,Amano_etal,2020,Observational,Terrestrial,Global,1,Unknown,Unknown
-23091,Ambastha_etal,2010,Observational,Terrestrial,Local,250,asia,India
-23100,Andersen_etal,2020,Observational,Marine,National,2,north atlantic,Denmark
-W26591,Anderson_etal,2017,Observational,Marine,Local,,north atlantic,Belize
-23105,Andrade-Díaz_etal,2019,Observational,Terrestrial,Sub-national,,south america,Argentina
-23106,Andréfouët_etal,2015,Observational,Marine,Multi-national,30,south pacific,Cook Islands
-23114,Anjos_etal,2018,Observational,Terrestrial,Continental,6,south america,Unknown
-23117,Ansari and Golabi,2019,Observational,Terrestrial,Local,,asia,Iran
-23128,Araújo and Wang,2015,Observational,Freshwater,Sub-national,,south america,Brazil
-23125,Araújo_etal,2008,Observational,Terrestrial,Continental,50,europe,Unknown
-23135,Arkema_etal,2014,Observational,Marine,National,500,north atlantic,Belize
-23138,Armenteras_etal,2013,Observational,Terrestrial,Local,,south america,Colombia
-23142,Arroyave_etal,2020,Observational,Terrestrial,National,,south america,Colombia
-23146,Asharfi_etal,2020,Observational,Terrestrial,Local,20,asia,Iran
-23147,Ashcroft_etal,2009,Observational,Terrestrial,Local,ha,australasia,Australia
-23151,Asner_etal,2009,Observational,Terrestrial,Global,500,Unknown,Unknown
-23150,Asner_etal,2008,Observational,Terrestrial,Local,3,north america,United States
-23154,Assuncao_etal,2019,Observational,Terrestrial,Sub-national,0.5,south america,Brazil
-23155,Astiaso_etal,2013,Observational,Terrestrial,National,,europe,Italy
-23160,Atkore_etal,2020,Observational,Freshwater,Sub-national,,asia,India
-23163,Aubrecht_etal,2008,Observational,Marine,Global,km,Unknown,Unknown
-23164,Auerbach_etal,2014,Observational,Terrestrial,Sub-national,25,australasia,Australia
-23169,Avila_etal,2018,S_Review,Marine,Global,0.5,Unknown,Unknown
-23170,Awkerman_etal,2016,Observational,Marine,Local,90,north atlantic,United States
-23171,Ayele_etal,2016,Observational,Terrestrial,Local,30,africa,Ethiopia
-23177,Bacigalupe_etal,2019,Observational,Terrestrial,National,1,south america,Chile
-23185,Bahaa-El-Din_etal,2016,Observational,Terrestrial,Local,,africa,Gabon
-23188,Baig and Aldosari,2012,Observational,Terrestrial,Local,,asia,Pakistan
-23190,Bailey_etal,2017,Observational,Terrestrial,Sub-national,25,north america,United States
-23196,Balasingham_etal,2018,Observational,Freshwater,Local,,north america,Canada
-23197,Baláž_etal,2014,Observational,Freshwater,Continental,,europe,Unknown
-23200,Balotari-Chiebao_etal,2018,Observational,Terrestrial,National,25,europe,Finland
-23202,Balzotti_etal,2016,Observational,Terrestrial,Sub-national,,north america,United States
-23207,Bangs_etal,2018,Observational,Freshwater,Local,,north america,United States
-23211,Barbarossa_etal,2020,Observational,Freshwater,Global,,Unknown,Unknown
-23222,Baret_etal,2006,Observational,Terrestrial,Local,500,africa,Mauritius
-23223,Barilani_etal,2007,Observational,Terrestrial,Multi-national,,europe,France
-23232,Barthelmess,2014,Observational,Terrestrial,Local,30,north america,United States
-23234,Bartolino_etal,2012,Observational,Marine,Sub-national,1369,north pacific,Alaska
-23236,Bartz_etal,2015,Observational,Freshwater,Local,30,north america,United States
-23237,Barve_etal,2005,Observational,Terrestrial,Local,30,asia,India
-23242,Bass_etal,2010,Observational,Terrestrial,Sub-national,100,south america,Ecuador
-23247,Battiston_etal,2012,Observational,Terrestrial,Local,0.5,europe,France
-23249,Bax_etal,2019,Observational,Terrestrial,Sub-national,,south america,Peru
-23252,Baynard_etal,2017,Observational,Terrestrial,Sub-national,1,north america,United States
-23256,Beaudry_etal,2008,Observational,Terrestrial,Local,,north america,United States
-23258,Bebbington_etal,2018,Observational,Terrestrial,Multi-national,,asia,Brazil
-23261,Becker and Zamudio,2011,Observational,Terrestrial,National,1,north america,Costa Rica
-23262,Bedrosian_etal,2020,Observational,Terrestrial,Sub-national,1,north america,United States
-23266,Bejaoui_etal,2020,Observational,Freshwater,Local,,africa,Tunisia
-23276,Bellard_etal,2016,Observational,Terrestrial,Global,10,Unknown,Unknown
-23278,Belpaire_etal,2015,Observational,Freshwater,Sub-national,,europe,Belgium
-23280,Ben Rais_etal,2016,Observational,Marine,Sub-national,0.1,mediterranean,Tunisia
-23282,Bendell and Wan,2011,Observational,Marine,Local,,north pacific,Canada
-23285,Bennett_etal,2010,Observational,Freshwater,Sub-national,,north america,Canada
-23290,Benslimane_etal,2019,Observational,Freshwater,Local,,africa,Algeria
-23293,Berthon_etal,2018,Observational,Terrestrial,National,1,australasia,Australia
-23301,Bezeng_etal,2020,Observational,Terrestrial,National,1,africa,South Africa
-23303,Bhatt_etal,2016,Observational,Freshwater,National,,asia,India
-23304,Bhola_etal,2012,Observational,Terrestrial,Local,25,africa,Kenya
-23306,Bi_etal,2020,Observational,Marine,Multi-national,,north atlantic,United States
-23313,Binothman,2016,Observational,Terrestrial,Sub-national,,asia,Saudi Arabia
-23315,Birkmanis_etal,2020,Observational,Marine,National,81,indian ocean,Australia
-23318,Bisi_etal,2019,Observational,Terrestrial,Local,m,asia,Myanmar
-23330,Böhm_etal,2013,Observational,Marine,Global,7770,Unknown,Unknown
-23331,Böhm_etal,2016,Observational,Marine,Global,7770,Unknown,Unknown
-23337,Bonesi_etal,2007,Observational,Freshwater,Local,25,europe,United Kingdom
-23340,Borah_etal,2016,Observational,Terrestrial,Sub-national,100,asia,India
-23343,Borrelli_etal,2015,Observational,Terrestrial,Local,500,south america,Colombia
-23345,Bose_etal,2020,Observational,Terrestrial,Sub-national,100,europe,Germany
-23350,Bouchard_etal,2015,Observational,Terrestrial,Local,,africa,South Africa
-23353,Boulanger_etal,2014,Observational,Terrestrial,Sub-national,,north america,Canada
-23355,Bourgoin_etal,2020,Observational,Terrestrial,Sub-national,10,asia,Thailand
-23357,Bozkaya_etal,2015,Observational,Terrestrial,Local,30,asia,Turkey
-23361,Bradley,2010,Observational,Terrestrial,Sub-national,30,north america,United States
-23362,Bradley_etal,2020,Observational,Freshwater,Sub-national,,north america,United States
-23364,Braunisch_etal,2011,Observational,Terrestrial,Local,25,europe,Switzerland
-23365,Breen_etal,2017,Observational,Marine,Sub-national,48,north atlantic,United Kingdom
-23368,Bright_etal,2008,Observational,Terrestrial,National,1,europe,United Kingdom
-23371,Briscoe_etal,2014,Observational,Terrestrial,Sub-national,1.44,asia,Malaysia
-23374,Brito_etal,2018,Observational,Terrestrial,Multi-national,,africa,Mauritania
-23378,Bröker_etal,2015,Observational,Marine,Sub-national,1,north pacific,Russia
-23384,Brown and Hamilton,2018,Observational,Marine,Local,,south pacific,Solomon Islands
-23383,Brown_etal,2014,Observational,Marine,National,,indian ocean,Australia
-23390,Bruschi_etal,2015,Observational,Terrestrial,National,250,europe,Italy
-23391,Bryce_etal,2002,Observational,Terrestrial,Local,,europe,United Kingdom
-23398,Buckland_etal,2014,Observational,Terrestrial,National,30,africa,Mauritius
-23399,Buckley_etal,2016,Observational,Terrestrial,National,1,asia,China
-23402,Buma_etal,2017,Observational,Terrestrial,Sub-national,,north america,United States
-23404,Bungnamei and Saikia,2020,Observational,Terrestrial,Local,60,asia,India
-23405,Burdett_etal,2010,Observational,Terrestrial,Sub-national,100,north america,United States
-23407,Burgess_etal,2016,Observational,Marine,Sub-national,90,north pacific,United States
-23409,Burivalova_etal,2020,Observational,Terrestrial,Sub-national,30,asia,Indonesia
-23412,Burton_etal,2012,Observational,Terrestrial,Local,500,africa,Ghana
-23418,Butsic_etal,2015,Observational,Terrestrial,National,,africa,DRC
-23424,Cadima_etal,2014,Observational,Terrestrial,National,5,south america,Bolivia
-23428,Callan_etal,2020,Observational,Terrestrial,Local,2.5,asia,China
-23429,Calle-Rendón_etal,2018,Observational,Terrestrial,National,0.1,south america,Colombia
-23430,Calvert_etal,2005,Observational,Terrestrial,Sub-national,,north america,Canada
-23438,Campana_etal,2018,Observational,Marine,Multi-national,25,mediterranean,Spain
-23448,Cao_etal,2020,Observational,Terrestrial,Sub-national,0.25,asia,China
-23449,Caorsi_etal,2014,Observational,Freshwater,Local,,south america,Brazil
-23452,Carassou_etal,2013,Observational,Marine,National,,south pacific,New Caledonia
-23454,Cardoso_etal,2018,Observational,Terrestrial,Sub-national,0.2,south america,Brazil
-23456,Carle_etal,2019,Observational,Marine,Sub-national,,south pacific,Chile
-23461,Caro_etal,2020,Observational,Terrestrial,Sub-national,,africa,Tanzania
-23464,Carrasco_etal,2020,Observational,Terrestrial,National,25,africa,Madagascar
-23466,Carrete_etal,2012,Experimental,Terrestrial,Sub-national,,europe,Spain
-W26579,Carroll,2018,Observational,Terrestrial,Multi-national,,asia,Myanmar
-23473,Carvajal-Quintero_etal,2017,Observational,Freshwater,Local,,south america,Colombia
-23477,Carvalho_etal,2019,Observational,Terrestrial,Sub-national,100,south america,Brazil
-23487,Cavalcante,2012,Observational,Marine,Local,,north atlantic,Canada
-23489,Ceballos-Mago_etal,2010,Observational,Terrestrial,National,,south america,Venezuela
-23490,Ceia-Hasse_etal,2017,Observational,Terrestrial,Global,10000,Unknown,Unknown
-W26584,Chanchani P._etal,2014,Observational,Terrestrial,Multi-national,15,asia,India
-W22911,Charity_etal,2016,Observational,Freshwater,Multi-national,,south america,Brazil
-23509,Chaudhary and Brooks,2019,Observational,Terrestrial,Global,,Unknown,Unknown
-23507,Chaudhary and Kastner,2016,Observational,Terrestrial,Global,,Unknown,Unknown
-23508,Chaudhary_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown
-23513,Chaves_etal,2020,Observational,Freshwater,Local,,south america,Brazil
-23515,Chee_etal,2017,Observational,Terrestrial,Local,,indian ocean,Malaysia
-23517,Chen,2014,Observational,Terrestrial,Local,,asia,China
-23518,Chen and Koprowski,2015,Observational,Terrestrial,Local,50,north america,United States
-23523,Cheng,2017,Observational,Terrestrial,Sub-national,,north america,United States
-23527,Chettri_etal,2013,Observational,Terrestrial,Local,,asia,Nepal
-23528,Chevaldonné and Lejeusne,2003,Observational,Marine,Local,,mediterranean,France
-23530,Chirichella_etal,2013,Observational,Terrestrial,Local,,europe,Italy
-23531,Choe and Thorne,2019,Observational,Terrestrial,Multi-national,,asia,China
-23534,Choquette Jonathan_etal,2020,Observational,Terrestrial,Local,0.3,north america,Canada
-23537,Chowdhury and Maiti,2016,Observational,Freshwater,Local,,asia,India
-23543,Chu_etal,2003,Observational,Freshwater,National,,north america,Canada
-23547,Chun_etal,2020,Observational,Terrestrial,National,1,asia,South Korea
-23552,Chytry_etal,2009,Observational,Terrestrial,Continental,250,europe,Unknown
-W26593,Cinner_etal,2018,Observational,Marine,Global,,Unknown,Unknown
-23559,Clare_etal,2019,Observational,Terrestrial,Local,250,north america,United States
-23560,Clark and Tittensor,2010,Observational,Marine,Global,1,Unknown,Unknown
-23565,Clarke_etal,2015,Observational,Marine,Sub-national,,north pacific,Canada
-23566,Clarke_etal,2018,Observational,Marine,National,,north pacific,Costa Rica
-23571,Clavero and García-Berthou,2006,Observational,Freshwater,Multi-national,,europe,France
-23572,Clavero_etal,2010,Observational,Freshwater,Multi-national,100,europe,Andorra
-23573,Clay_etal,2019,Observational,Marine,Global,5,Unknown,Unknown
-23576,Clements_etal,2014,Observational,Terrestrial,Local,1,asia,Malaysia
-23581,Codato_etal,2019,Observational,Terrestrial,Multi-national,,south america,Brazil
-23582,Coll_etal,2012,Observational,Marine,Multi-national,0.1,mediterranean,Bosnia and Herzegovina
-23583,Coll_etal,2015,Observational,Marine,Multi-national,0.1,mediterranean,Bosnia and Herzegovina
-23588,Compa_etal,2019,Observational,Marine,Multi-national,0.2,mediterranean,Bosnia and Herzegovina
-23591,Comte and Olden,2017,Observational,Freshwater,Global,0.1,Unknown,Unknown
-23594,Coppes and Braunisch,2013,Observational,Terrestrial,Local,10,europe,Germany
-23595,Coppes_etal,2017,Observational,Terrestrial,Local,10,europe,Germany
-23598,Coristine and Kerr,2015,Observational,Terrestrial,Multi-national,5,north america,United States
-23599,Coristine_etal,2016,Observational,Terrestrial,Multi-national,5,north america,Canada
-23602,Correa_etal,2020,Observational,Terrestrial,National,300,south america,Colombia
-23603,Cosandey-Godin_etal,2014,Observational,Marine,Sub-national,1,arctic ocean,Canada
-23609,Courtois_etal,2015,Observational,Terrestrial,National,,south america,French Guiana
-23612,Cowburn_etal,2018,Observational,Marine,National,,south atlantic,Comoros
-23613,Cowles_etal,2012,Observational,Freshwater,Sub-national,,north america,United States
-23614,Craig_etal,2019,Observational,Terrestrial,National,,africa,Namibia
-23616,Crano,2016,Observational,Terrestrial,Local,10,north america,United States
-23620,Critchell_etal,2019,Observational,Marine,Local,,south pacific,Australia
-23623,Croquer_etal,2016,Observational,Marine,Local,,north atlantic,Venezuela
-23626,Crosti_etal,2017,Observational,Marine,Local,,mediterranean,Italy
-23631,Cubero-Pardo_etal,2011,Observational,Marine,Sub-national,22.2,north pacific,Mexico
-23633,Cuevas_etal,2019,Observational,Marine,Sub-national,1,north atlantic,Mexico
-23639,Cunningham_etal,2013,Observational,Terrestrial,National,,africa,South Africa
-23641,Curatola_etal,2015,Observational,Terrestrial,Local,,south america,Ecuador
-23649,D’amico_etal,2019,Observational,Terrestrial,Multi-national,10,europe,Portugal
-23651,Dahdouh-Guebas_etal,2002,Observational,Terrestrial,Local,,indian ocean,Sri Lanka
-23652,Dalle_etal,2019,Observational,Terrestrial,Local,,south america,Brazil
-23653,Dalu_etal,2017,Observational,Freshwater,Local,,africa,Zimbabwe
-23654,Daly_etal,2018,Observational,Marine,Multi-national,5,indian ocean,South Africa
-23647,D'amico_etal,2015,Observational,Terrestrial,Local,,europe,Spain
-23656,Dang_etal,2019,Observational,Terrestrial,Global,30,Unknown,Unknown
-23657,Dang_etal,2020,Observational,Terrestrial,Sub-national,1,asia,China
-23660,Darwall_etal,2011,Observational,Freshwater,Continental,,africa,Unknown
-23663,Das_etal,2020,Observational,Freshwater,Local,,asia,India
-23664,Dasgupta and Ghosh,2015,Observational,Terrestrial,Local,,asia,India
-23666,Dávalos_etal,2011,Observational,Terrestrial,National,1,south america,Colombia
-23669,De Abreu_etal,2011,Observational,Terrestrial,Local,,south america,Brazil
-23670,De Alban_etal,2020,Observational,Terrestrial,Local,30,asia,Myanmar
-23674,De Castro_etal,2017,Observational,Terrestrial,Sub-national,km2,south america,Brazil
-23682,De Luna_etal,2018,Observational,Terrestrial,Local,,south america,Colombia
-23684,De Noronha_etal,2013,Observational,Terrestrial,Local,,europe,Portugal
-23685,De Oliveira_etal,2020,Observational,Freshwater,Sub-national,25,south america,Brazil
-23689,De Solan_etal,2019,Observational,Terrestrial,Sub-national,1,europe,France
-23691,De Sousa_etal,2011,Observational,Freshwater,Local,,south america,Brazil
-23694,De Thoisy_etal,2010,Observational,Terrestrial,National,1,south america,French Guiana
-23698,Death_etal,2019,Observational,Terrestrial,Local,,australasia,Australia
-23700,Deb_etal,2019,Observational,Terrestrial,Continental,1,asia,Unknown
-23699,Deb_etal,2014,Observational,Terrestrial,Local,,asia,India
-23701,Deb_etal,2020,Observational,Terrestrial,Sub-national,,asia,India
-23704,Deith and Brodie,2020,Observational,Terrestrial,Sub-national,,asia,Malaysia
-23706,Delefosse_etal,2018,Observational,Marine,Sub-national,,north atlantic,Denmark
-23710,Delsen,2020,Observational,Terrestrial,Continental,9,europe,Unknown
-23713,Deribew,2019,Observational,Terrestrial,Local,10,africa,Ethiopia
-23714,Desta and Fetene,2020,Observational,Freshwater,Local,57,africa,Ethiopia
-23718,Deudero and Alomar,2015,S_Review,Marine,Multi-national,,mediterranean,Bosnia and Herzegovina
-23726,Di_etal,2018,Observational,Terrestrial,Global,1,Unknown,Unknown
-23727,Di_etal,2019,Observational,Terrestrial,Global,30,Unknown,Unknown
-23722,Di_etal,2019,Observational,Terrestrial,Continental,,europe,Unknown
-23728,Di_etal,2013,Observational,Terrestrial,Sub-national,200,africa,South Africa
-23730,Di_etal,2016,Observational,Marine,Local,1,south atlantic,Brazil
-23737,"Dignan, S.P.,",2014,Observational,Marine,Local,1,north atlantic,United Kingdom
-23738,Dillon Whalen_etal,2013,Observational,Terrestrial,Sub-national,1,north america,United States
-23739,Dimitrakopoulos_etal,2017,Observational,Terrestrial,National,,europe,Greece
-23740,Dimobe_etal,2015,Observational,Terrestrial,Sub-national,30,africa,Sudan
-23743,Diwediga_etal,2015,Observational,Terrestrial,Local,,africa,Togo
-23744,Diwediga_etal,2017,Observational,Terrestrial,Multi-national,,africa,Burkina Faso
-23753,Doherty,2008,Observational,Terrestrial,Sub-national,,north america,United States
-23754,Doherty_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown
-23759,Dong_etal,2018,Observational,Terrestrial,National,,asia,China
-23760,Dorcas_etal,2012,Observational,Terrestrial,Local,,north america,United States
-23771,Dransfield_etal,2014,Observational,Marine,Local,1,north pacific,United States
-23773,Duan_etal,2020,Observational,Freshwater,National,30,asia,China
-23779,Dulvy_etal,2014,Observational,Marine,Global,,Unknown,Unknown
-23780,Duncan_etal,2014,Observational,Terrestrial,Multi-national,,africa,Algeria
-23782,Duncan_etal,2018,Observational,Terrestrial,Multi-national,62.5,south atlantic,Bangladesh
-23785,Duran,2008,Observational,Marine,Local,,north atlantic,Spain
-23787,Durango-Cordero_etal,2018,Observational,Freshwater,Sub-national,25,south america,Ecuador
-23788,Dutta_etal,2017,Observational,Terrestrial,Local,m,asia,India
-23790,Duvall and Barron,2000,Experimental,Freshwater,Local,,north america,United States
-23791,Dwyer_etal,2016,Observational,Terrestrial,Sub-national,1,north america,United States
-23793,Dzialak_etal,2011,Observational,Terrestrial,Local,,north america,United States
-23795,Easterday_etal,2016,Observational,Terrestrial,Sub-national,1,north america,United States
-23796,Ebdon_etal,2020,Observational,Marine,Sub-national,250,south pacific,New Zealand
-23804,Eguchi_etal,2017,Observational,Marine,Sub-national,0.5,north pacific,United States
-23816,Elleouet_etal,2014,Observational,Marine,Multi-national,0.1,mediterranean,Bosnia and Herzegovina
-23823,Enrichetti_etal,2019,Observational,Marine,Multi-national,,mediterranean,Italy
-23824,Enríquez-Andrade_etal,2005,Observational,Marine,Sub-national,,north pacific,United States
-23825,Epa and Mohotti,2016,Observational,Freshwater,Local,,asia,Sri Lanka
-23828,Erbe_etal,2014,Observational,Marine,Sub-national,25,north pacific,Canada
-23832,Escobar_etal,2015,Observational,Terrestrial,Continental,21.16,asia,Unknown
-23833,Esetlili_etal,2014,Observational,Terrestrial,Local,15,asia,Turkey
-23836,Espinoza-Tenorio_etal,2010,Observational,Marine,Local,,north pacific,United States
-23838,Esselman and Allan,2011,Observational,Freshwater,Multi-national,,north america,Mexico
-23841,Estoque and Murayama,2012,Observational,Terrestrial,Local,30,asia,Philippines
-23845,Etter_etal,2011,Observational,Terrestrial,National,1,south america,Colombia
-23847,Evans_etal,2011,Observational,Terrestrial,National,,australasia,Australia
-23848,Evans_etal,2011,Observational,Freshwater,National,,australasia,Australia
-23854,Fa_etal,2013,Observational,Terrestrial,Multi-national,,africa,Cameroon
-W26589,Fabian C. Kyne_etal,2020,Observational,Marine,Multi-national,,north atlantic,Anguilla
-23855,Fabrizio_etal,2019,Observational,Terrestrial,Sub-national,40,europe,Italy
-23856,Fabrizio_etal,2019,Observational,Terrestrial,Sub-national,1,europe,Italy
-23858,Fakarayi_etal,2015,Observational,Terrestrial,Local,,africa,Zimbabwe
-23864,Farella_etal,2020,Observational,Marine,Local,250,mediterranean,Italy
-23865,Farfán_etal,2019,Observational,Terrestrial,Local,0.25,africa,Cameroon
-23866,Fargione_etal,2012,Observational,Terrestrial,Sub-national,200,north america,United States
-23867,Farizal_etal,2020,Observational,Terrestrial,Local,,asia,Indonesia
-23868,Fasola and Roesler,2018,Observational,Terrestrial,Sub-national,2500,south america,Argentina
-23869,Fassnacht_etal,2015,Observational,Terrestrial,Sub-national,30,asia,China
-23870,Fauzi_etal,2019,Observational,Terrestrial,Multi-national,1,south china sea,Myanmar
-23871,Favilli_etal,2018,Observational,Terrestrial,Sub-national,,europe,Italy
-23877,Feist_etal,2011,Observational,Marine,Local,30,north pacific,United States
-23879,Feitosa_etal,2018,Observational,Marine,Sub-national,,north atlantic,Brazil
-23881,Felton Annika_etal,2013,Observational,Terrestrial,Multi-national,,south america,Bolivia
-23888,Fernandes_etal,2017,Observational,Marine,National,25,north atlantic,Portugal
-23889,Fernandes_etal,2020,Observational,Marine,National,,north atlantic,Portugal
-23891,Fernández-Bellon,2020,S_Review,Terrestrial,Global,,Unknown,Unknown
-25210,Ferrarini_etal,2021,Observational,Terrestrial,Sub-national,,europe,Italy
-23893,Ferreguetti Á_etal,2018,Observational,Terrestrial,Local,,south america,Brazil
-23903,Filius_etal,2020,Observational,Terrestrial,Local,,south america,Ecuador
-23904,Findlay_etal,2018,Observational,Marine,Sub-national,25,north atlantic,United Kingdom
-23905,Finer_etal,2008,Observational,Terrestrial,Multi-national,,south america,Brazil
-23906,Fiorini_etal,2017,Observational,Terrestrial,Sub-national,,europe,Italy
-23909,Flechas_etal,2017,Observational,Terrestrial,Sub-national,,south america,Colombia
-23912,Flory_etal,2012,Observational,Terrestrial,Sub-national,,north america,United States
-23913,Floyd_etal,2006,Observational,Terrestrial,Local,,north america,United States
-23915,Focardi_etal,2006,Observational,Freshwater,Multi-national,,africa,Kenya
-23917,Foden_etal,2013,Observational,Freshwater,Global,1,Unknown,Unknown
-23920,Fonnesbeck_etal,2008,Observational,Marine,Local,16,north atlantic,United States
-23922,Foo and Numata,2019,Observational,Terrestrial,Local,30,asia,Malaysia
-23927,Fort_etal,2013,Observational,Marine,Multi-national,,arctic ocean,Greenland
-23929,Fortini Lucas_etal,2019,Observational,Terrestrial,Sub-national,500,north america,United States
-23932,Foveau_etal,2017,Observational,Marine,Sub-national,0.03,north atlantic,United Kingdom
-23936,Foxcroft_etal,2007,Observational,Freshwater,Sub-national,,africa,South Africa
-23937,Foxcroft_etal,2009,Observational,Freshwater,Sub-national,25,africa,South Africa
-23938,Francesco_etal,2019,Observational,Terrestrial,Local,,europe,Italy
-23941,Fraschetti_etal,2016,Observational,Marine,Local,,mediterranean,Italy
-23946,Fremout_etal,2020,Observational,Terrestrial,Multi-national,30,south america,Ecuador
-23951,Fryxell_etal,2020,Observational,Terrestrial,Sub-national,,north america,Canada
-23953,Fuentes_etal,2016,Observational,Terrestrial,Sub-national,m,north atlantic,United States
-23955,Fugère_etal,2018,Observational,Freshwater,Local,,africa,Uganda
-23957,Furlan_etal,2018,Observational,Marine,Multi-national,100,mediterranean,Italy
-23958,Furlan_etal,2019,Observational,Marine,Multi-national,,mediterranean,Italy
-23960,Gabriel_etal,2012,Observational,Terrestrial,Sub-national,,north america,United States
-23964,Gaines_etal,2005,Observational,Freshwater,Local,10,north america,United States
-23967,Gairola_etal,2016,Observational,Terrestrial,Local,0.5,africa,South Africa
-23968,Gaisberger_etal,2017,Observational,Terrestrial,Sub-national,2.5,africa,Burkina Faso
-23969,Gaisberger_etal,2020,Observational,Terrestrial,Multi-national,30,asia,Kyrgyzstan
-23977,Gallagher_etal,2019,Observational,Terrestrial,Continental,10000,australasia,Australia
-23975,Gallagher_etal,2008,Observational,Terrestrial,Local,10,north america,United States
-23978,Gallão and Bichuette,2018,Observational,Terrestrial,Sub-national,,south america,Brazil
-23979,Gallardo and Aldridge,2013,Observational,Freshwater,Continental,16,europe,Unknown
-23980,Gallardo_etal,2017,Observational,Freshwater,Continental,30,europe,Unknown
-23982,Gallego-Zamorano_etal,2020,Observational,Terrestrial,Global,30,Unknown,Unknown
-23985,Gaoue and Ticktin,2007,Observational,Terrestrial,National,,africa,Benin
-23988,Garcês_etal,2019,Observational,Terrestrial,Sub-national,,europe,Portugal
-23989,Garcia_etal,2014,Observational,Freshwater,Multi-national,1,africa,Angola
-23991,García-Barcelona_etal,2010,Observational,Marine,Sub-national,,mediterranean,Spain
-23992,Garcia-Carrasco_etal,2020,Observational,Terrestrial,Local,,south america,Ecuador
-23993,Garcia-De-Vinuesa_etal,2018,Observational,Marine,Local,1,mediterranean,Spain
-23997,Gargan_etal,2011,Observational,Freshwater,Local,,europe,Ireland
-24000,Garrard_etal,2016,Observational,Terrestrial,Local,200,asia,Nepal
-24001,Garratt_etal,2019,Observational,Terrestrial,Local,6,north atlantic,United Kingdom
-24003,Garrote_etal,2018,Observational,Terrestrial,Sub-national,,europe,Spain
-24013,Genovart_etal,2017,Observational,Marine,Multi-national,0.1,mediterranean,Spain
-24016,Gerlach,2002,Observational,Terrestrial,Local,,north america,United States
-24024,Ghorbani_etal,2014,Observational,Terrestrial,Sub-national,,asia,Iran
-24025,Ghulam_etal,2015,Observational,Terrestrial,Local,30,africa,Madagascar
-24029,Gibson_etal,2018,Observational,Terrestrial,Local,,north america,United States
-24030,Giersch_etal,2015,Observational,Terrestrial,Local,,north america,United States
-24034,Gillen and Kiviat,2012,Observational,Terrestrial,Sub-national,,north america,United States
-24036,Gilman_etal,2008,Experimental,Marine,Local,,north pacific,Hawaii
-24038,Gimpel_etal,2013,Observational,Marine,Local,5,north atlantic,Germany
-24039,Giordano_etal,2008,Observational,Terrestrial,Local,,south america,Argentina
-24042,Girardet_etal,2015,Observational,Terrestrial,Sub-national,10,europe,France
-24050,Goldberg_etal,2020,Observational,Marine,Global,30,Unknown,Unknown
-24053,Gomez_etal,2014,Observational,Freshwater,Local,0.05,south america,Argentina
-24055,Gomez_etal,2017,Observational,Marine,Sub-national,1,north atlantic,Canada
-24060,González-Andrés_etal,2020,Observational,Marine,Local,0.03,north pacific,Costa Rica
-24062,Gonzalez-Quevedo_etal,2014,Observational,Terrestrial,Sub-national,,europe,Spain
-24064,Gonzalez-Suarez_etal,2013,Observational,Marine,Global,2,Unknown,Unknown
-24065,González-Suárez_etal,2018,Observational,Terrestrial,National,1,south america,Brazil
-24067,Good_etal,2020,Observational,Marine,Sub-national,4.8,north pacific,United States
-24078,Graham_etal,2016,Observational,Terrestrial,Global,1,Unknown,Unknown
-24079,Grainger_etal,2018,Observational,Terrestrial,Multi-national,1,asia,Myanmar
-24086,Grecchi_etal,2014,Observational,Freshwater,Sub-national,,south america,Brazil
-24088,Grech and Marsh,2008,Observational,Marine,Sub-national,,south pacific,Australia
-24087,Grech_etal,2008,Observational,Marine,Sub-national,,south pacific,Australia
-24094,Grenouillet and Comte,2014,Observational,Freshwater,National,64,europe,France
-24096,Grigolato_etal,2018,Observational,Terrestrial,Local,,europe,Italy
-24101,Guerra_etal,2017,Observational,Terrestrial,Local,,south america,Brazil
-24104,Guerrini_etal,2019,Observational,Marine,Sub-national,,europe,Italy
-24107,Gül and Griffen,2018,Observational,Marine,Local,,north america,United States
-24108,Gumbs_etal,2020,Observational,Terrestrial,Global,1,Unknown,Unknown
-24110,Gunson_etal,2012,Observational,Terrestrial,Local,15,north america,Canada
-24113,Guo_etal,2018,Observational,Terrestrial,Global,0.5,Unknown,Unknown
-24112,Guo_etal,2005,Observational,Terrestrial,Sub-national,1,north america,United States
-24114,Gutiérrez_etal,2020,Observational,Terrestrial,Local,1,europe,Spain
-24120,Hager_etal,2013,Observational,Terrestrial,Local,,north america,United States
-24122,Haines_etal,2010,Observational,Terrestrial,Sub-national,90,north america,United States
-24123,Hajiahmadi and Amanollahi,2018,Observational,Terrestrial,Local,,asia,Indonesia
-24125,Halpern_etal,2008,Observational,Marine,Global,,Unknown,Unknown
-24126,Halpern_etal,2009,Observational,Marine,Global,,Unknown,Unknown
-24128,Halpern_etal,2015,Observational,Marine,Global,1,Unknown,Unknown
-24127,Halpern_etal,2009,Observational,Marine,Sub-national,1,north pacific,United States
-24129,Hamilton_etal,2016,Observational,Marine,Local,,south pacific,Solomon Islands
-24133,Hammouda_etal,2019,Observational,Terrestrial,Local,,africa,Algeria
-24138,Han_etal,2019,Observational,Freshwater,Sub-national,16,asia,China
-24139,Han_etal,2019,Observational,Terrestrial,Sub-national,km2,asia,China
-24140,Handley_etal,2020,Observational,Marine,Sub-national,,southern ocean,South Georgia and the South Sandwich Islands
-24145,Hao_etal,2018,Observational,Terrestrial,Sub-national,1,asia,China
-24149,Hari_etal,2014,Observational,Terrestrial,Sub-national,500,asia,India
-24150,Harik_etal,2017,Observational,Terrestrial,Local,15,africa,France
-24153,Harris_etal,2014,Observational,Terrestrial,Local,30,asia,Indonesia
-24154,Harris_etal,2017,Observational,Marine,Multi-national,5,indian ocean,South Africa
-24155,Harrison_etal,2011,Observational,Terrestrial,Sub-national,,asia,Indonesia
-24156,Harsch and Hillerislambers,2016,Observational,Terrestrial,Sub-national,,north america,Canada
-24158,Hart_etal,2014,Observational,Marine,Sub-national,100,north atlantic,United States
-24159,Hart_etal,2018,Observational,Marine,Sub-national,100,north atlantic,United States
-24160,Hassan_etal,2018,Observational,Terrestrial,Local,10,asia,Bangladesh
-24162,Hauser_etal,2018,Observational,Marine,Multi-national,,arctic ocean,Canada
-24163,Hausmann_etal,2019,Observational,Terrestrial,Global,1,Unknown,Unknown
-24167,Hayashi_etal,2018,Observational,Terrestrial,Sub-national,5,south america,Brazil
-24169,Hayes_etal,2015,Observational,Terrestrial,Multi-national,1,north america,Canada
-24170,Haywood_etal,2016,Observational,Marine,Local,,south pacific,Papua New Guinea
-24174,He_etal,2018,Observational,Freshwater,Global,10,Unknown,Unknown
-24175,Heard_etal,2015,Observational,Freshwater,Local,,australasia,Australia
-24177,Hedd_etal,2016,Observational,Marine,Sub-national,10000,arctic ocean,Canada
-24180,Hegland and Hamre,2018,Observational,Terrestrial,Sub-national,,europe,Norway
-24184,Hein_etal,2015,Observational,Marine,Local,,south china sea,Thailand
-24186,Heinemeyer_etal,2019,Observational,Terrestrial,Sub-national,,north america,United States
-24188,Heinrich_etal,2019,Observational,Marine,Local,,south pacific,Chile
-24192,Helldin,2019,Observational,Terrestrial,National,,europe,Sweden
-24194,Hemami_etal,2018,Observational,Marine,Local,4,indian ocean,Iran
-24195,Henriques_etal,2014,Observational,Marine,National,1,north atlantic,Portugal
-24197,Herder_etal,2012,Observational,Freshwater,Local,,asia,Indonesia
-24199,Hermoso_etal,2015,Observational,Freshwater,Sub-national,,australasia,Australia
-24202,Hernández-Lambraño_etal,2018,Observational,Terrestrial,Sub-national,20,europe,Spain
-24203,Hernández-Matías_etal,2020,Observational,Terrestrial,Sub-national,100,europe,Spain
-24205,Hernout_etal,2018,Observational,Terrestrial,National,100,europe,United Kingdom
-24206,Herr_etal,2009,Observational,Marine,Sub-national,36,north atlantic,Germany
-24208,Hervé_etal,2016,Observational,Freshwater,Sub-national,100,europe,France
-24211,Hiddink_etal,2015,Observational,Marine,Multi-national,0.2,north atlantic,United Kingdom
-24212,Hierink_etal,2020,Observational,Terrestrial,Global,,Unknown,Unknown
-24215,Hillers_etal,2008,Observational,Terrestrial,Local,m,africa,Guinea
-24222,Hogan_etal,2012,Observational,Freshwater,Sub-national,30,north america,United States
-W26586,Hogg_etal,2010,Observational,Marine,Sub-national,,arctic ocean,Canada
-24227,Holon_etal,2015,Observational,Marine,Sub-national,20,mediterranean,France
-24228,Holon_etal,2015,Observational,Marine,Local,25,mediterranean,France
-24229,Holon_etal,2018,Observational,Marine,Multi-national,50,mediterranean,France
-24232,Hornseth_etal,2018,Observational,Terrestrial,Sub-national,1,north america,United States
-24242,Howard_etal,2018,Observational,Freshwater,Sub-national,,north america,United States
-24247,Hu_etal,2018,Observational,Marine,Sub-national,30,north atlantic,United States
-24253,Hughes,2019,Observational,Terrestrial,Global,,Unknown,Unknown
-24256,Hui_etal,2020,Observational,Terrestrial,Local,,asia,China
-24257,Hull_etal,2011,Observational,Terrestrial,Local,,asia,China
-24258,Hull_etal,2014,Observational,Terrestrial,Local,m,asia,China
-W26592,Humber_etal,2014,S_Review,Marine,Global,,Unknown,Unknown
-24262,Hurley_etal,2019,Observational,Marine,Sub-national,25,north atlantic,Canada
-24265,Hyde_etal,2018,Observational,Terrestrial,Sub-national,30,south america,Brazil
-24266,Iacona_etal,2014,Observational,Terrestrial,Sub-national,30,south america,Brazil
-24267,Iacona_etal,2016,Observational,Terrestrial,Sub-national,,north america,United States
-24268,Ibanez_etal,2019,Observational,Terrestrial,National,,australasia,New Caledonia
-24269,Ibharim_etal,2015,Observational,Terrestrial,Local,,asia,Malaysia
-24270,Ibouroi_etal,2019,Observational,Terrestrial,Local,,africa,Comoros
-24274,Iglesias-Merchan_etal,2015,Observational,Terrestrial,Local,100,europe,Spain
-24288,Ioki_etal,2019,Observational,Terrestrial,Local,,asia,Malaysia
-24290,Issaris_etal,2012,Observational,Marine,Sub-national,,mediterranean,Greece
-24291,Isunju and Kemp,2016,Observational,Freshwater,Local,,africa,Uganda
-24295,Jackson_etal,2020,Observational,Terrestrial,Global,1,Unknown,Unknown
-25557,Jacoby_etal,2020,Observational,Marine,Local,0.01,indian ocean,Chagos Archipelago
-24297,Jalali_etal,2015,Observational,Marine,Local,,indian ocean,Australia
-24299,Janik_etal,2020,Observational,Terrestrial,Local,0.25,europe,Czech Republic
-24302,Jaric_etal,2019,Observational,Freshwater,Continental,,europe,Unknown
-24304,Jarvis_etal,2010,Observational,Terrestrial,Continental,1,south america,Unknown
-24307,Jenkins_etal,2016,Observational,Marine,Global,2500,Unknown,Unknown
-24310,Jensen_etal,2019,Observational,Terrestrial,Global,,Unknown,Unknown
-24313,Jézéquel_etal,2020,Observational,Freshwater,Multi-national,,south america,Brazil
-24314,"Jia,S.",2016,Observational,Terrestrial,Sub-national,1,north america,United States
-24315,Jiang_etal,2020,Observational,Terrestrial,Continental,30,africa,Unknown
-24328,Jones Alice_etal,2018,Observational,Marine,Sub-national,250,indian ocean,Australia
-24322,Jones and Power,2012,Observational,Terrestrial,Sub-national,5,europe,United Kingdom
-24321,Jones_etal,2009,Observational,Freshwater,National,,africa,Madagascar
-24326,Jones_etal,2017,Observational,Marine,National,25,north atlantic,United Kingdom
-24329,Jongsomjit_etal,2013,Observational,Terrestrial,Sub-national,800,north america,United States
-24341,Kahler_etal,2012,Observational,Terrestrial,Local,10,africa,Namibia
-24345,Kamino_etal,2020,Observational,Freshwater,Sub-national,,south america,Brazil
-24346,Kamp_etal,2015,Observational,Terrestrial,Continental,degrees,asia,Unknown
-24347,Kamrowski_etal,2014,Observational,Marine,National,,indian ocean,Australia
-24352,Kano_etal,2016,Observational,Freshwater,Multi-national,km2,asia,Cambodia
-24353,Kantola_etal,2019,Observational,Terrestrial,Sub-national,30,north america,United States
-24358,Karimi and Jones,2020,Observational,Terrestrial,National,100,asia,Iran
-24364,Katsis_etal,2018,Observational,Terrestrial,Local,,africa,Kenya
-24365,Katzner_etal,2020,Observational,Terrestrial,Sub-national,,north america,United States
-24366,Kauano É_etal,2017,Observational,Freshwater,Sub-national,,south america,Brazil
-24368,Kehoe_etal,2015,Observational,Terrestrial,Global,12100,Unknown,Unknown
-24372,Keith_etal,2012,Observational,Terrestrial,Local,25,australasia,Australia
-24375,Kelly and Meentemeyer,2002,Observational,Terrestrial,Sub-national,5,north america,United States
-24381,Khaliq_etal,2014,Observational,Terrestrial,Global,,Unknown,Unknown
-24389,Kidane_etal,2012,Observational,Terrestrial,Local,2.5,africa,Ethiopia
-24391,Kilshaw_etal,2016,Observational,Terrestrial,Sub-national,500,europe,United Kingdom
-24392,Kim_etal,2020,Observational,Marine,National,0.5,north pacific,South Korea
-24395,Kirk_etal,2019,Observational,Terrestrial,Local,,africa,Tunisia
-24396,Kirkman_etal,2019,Observational,Marine,Multi-national,km2,south atlantic,Angola
-24397,Kirol_etal,2015,Observational,Terrestrial,Local,30,north america,United States
-24400,Kitzes and Shirley,2016,Observational,Freshwater,Sub-national,,asia,Malaysia
-24401,Kitzes_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown
-24404,Klarenberg_etal,2019,Observational,Freshwater,Sub-national,,south america,Brazil
-24411,Knouft and Chu,2015,Observational,Freshwater,Local,30,north america,United States
-24415,Koen_etal,2018,Observational,Freshwater,Global,400,Unknown,Unknown
-24416,Koerner_etal,2017,Observational,Terrestrial,Multi-national,,africa,Gabon
-24417,Kokkonen_etal,2010,Observational,Marine,Local,1,arctic ocean,Finland
-24418,Kolbe_etal,2016,Observational,Terrestrial,Sub-national,,north america,United States
-24420,Kominoski_etal,2018,Observational,Freshwater,Sub-national,,north america,United States
-24421,Konstantopoulos_etal,2020,Observational,Terrestrial,National,100,europe,Cyprus
-24422,Kooistra_etal,2005,Observational,Terrestrial,Local,,europe,Netherlands
-24423,Kope?_etal,2020,Observational,Terrestrial,Local,1,europe,Poland
-24426,Korpilo_etal,2018,Observational,Freshwater,Local,,europe,Finland
-24428,Kostoski_etal,2010,Observational,Freshwater,Local,,europe,Albania
-24431,Kovach_etal,2017,Observational,Freshwater,Local,,north america,Canada
-24436,Kraus_etal,2012,Observational,Terrestrial,Sub-national,,north america,United States
-24437,Krawczyk_etal,2019,Observational,Terrestrial,Local,,europe,Greece
-24443,Kuemmerle_etal,2014,Observational,Terrestrial,Sub-national,10,asia,Russia
-24446,Kumagai_etal,2018,Observational,Marine,Sub-national,1,north pacific,Japan
-24450,Kurekin_etal,2019,Observational,Marine,National,20,north atlantic,Ghana
-24451,Kurland_etal,2018,Observational,Terrestrial,Local,1,north america,United States
-24455,Kwak_etal,2019,Observational,Freshwater,Local,,north america,United States
-24460,Lagabrielle_etal,2009,Observational,Terrestrial,Local,25,africa,Reunion
-24461,Lagabrielle_etal,2018,Observational,Marine,Sub-national,10,indian ocean,South Africa
-24465,Laneri_etal,2010,Observational,Marine,Multi-national,,mediterranean,Morocco
-24471,Lasky_etal,2011,Observational,Terrestrial,Multi-national,,north america,United States
-24472,Laslo,2017,Observational,Freshwater,Local,,europe,Romania
-24473,Lasram_etal,2016,Observational,Marine,National,0.1,mediterranean,Tunisia
-24474,Latrubesse_etal,2020,Observational,Freshwater,Multi-national,,south america,Bolivia
-24475,Lattuada_etal,2020,Observational,Marine,Multi-national,,caspian sea,Russia
-24481,Lavorel_etal,2020,Observational,Terrestrial,Local,10,europe,France
-24483,Lawler_etal,2003,Observational,Terrestrial,Sub-national,1,north america,United States
-W26587,Leach_etal,2016,Observational,Terrestrial,Continental,10000,africa,Unknown
-24500,Leclerc_etal,2018,Observational,Freshwater,Global,,Unknown,Unknown
-24502,Lee and Jetz,2008,Observational,Terrestrial,Global,0.5,Unknown,Unknown
-24503,Lee_etal,2016,Observational,Marine,Sub-national,1,north pacific,United States
-24507,Leeney_etal,2008,Observational,Marine,Sub-national,400,north atlantic,United Kingdom
-24511,Lehnert_etal,2014,Observational,Terrestrial,Sub-national,,europe,Germany
-24516,Leprieur_etal,2008,Observational,Freshwater,Global,0.5,Unknown,Unknown
-24518,Lessmann_etal,2019,Observational,Freshwater,Sub-national,0.25,south america,Ecuador
-24525,Lewis_etal,2020,Observational,Terrestrial,Global,,Unknown,Unknown
-24536,Li_etal,2016,Observational,Terrestrial,Global,10,Unknown,Unknown
-24527,Li_etal,2011,Observational,Terrestrial,Sub-national,1,australasia,Australia
-24531,Li_etal,2011,Observational,Terrestrial,Local,,asia,China
-24540,Li_etal,2017,Observational,Terrestrial,Local,,north america,United States
-24544,Li_etal,2018,Observational,Terrestrial,Sub-national,1,asia,China
-24545,Li_etal,2018,Observational,Terrestrial,Sub-national,,asia,China
-24548,Li_etal,2019,Observational,Terrestrial,Local,,asia,China
-24551,Li_etal,2019,Observational,Terrestrial,Sub-national,,asia,China
-26547,Li_etal,2010,Observational,Freshwater,Local,100,asia,China
-24553,Licata_etal,2019,Observational,Terrestrial,Local,,africa,Madagascar
-24556,Liermann_etal,2012,Observational,Freshwater,Global,,Unknown,Unknown
-24557,Lieske_etal,2014,Observational,Marine,Sub-national,1,north atlantic,Canada
-24558,Lieske_etal,2020,Observational,Marine,Sub-national,400,north atlantic,Canada
-24565,Lin_etal,2008,Observational,Terrestrial,Local,,asia,China
-24566,Lin_etal,2019,Observational,Terrestrial,National,km,asia,Taiwan
-24567,Lin_etal,2020,Observational,Terrestrial,Local,,asia,Taiwan
-24574,Lindsey_etal,2016,Observational,Terrestrial,Continental,,africa,Angola
-24573,Lindsey_etal,2011,Observational,Terrestrial,Local,1,africa,Zimbabwe
-24576,Linke_etal,2013,Observational,Terrestrial,Local,,north america,Canada
-24579,Lipp-Nissinen_etal,2018,Observational,Terrestrial,Local,,south america,Brazil
-24582,Liu_etal,2008,Observational,Terrestrial,Sub-national,,asia,China
-24585,Liu_etal,2012,Observational,Terrestrial,Local,,north america,United States
-24590,Liu_etal,2018,Observational,Terrestrial,Local,,asia,China
-24595,Liu_etal,2020,Observational,Freshwater,Sub-national,,asia,China
-24597,Livingston_etal,2017,Observational,Terrestrial,Sub-national,,north america,United States
-24600,Loerzel_etal,2017,Observational,Marine,Local,1,north atlantic,United States Virgin Islands
-24601,Löfvenhaft_etal,2004,Observational,Terrestrial,Local,,europe,Sweden
-24605,Lohse_etal,2008,Observational,Freshwater,Local,,north america,United States
-24606,Loosen_etal,2019,Observational,Terrestrial,Sub-national,,north america,Canada
-24612,López-Sánchez_etal,2014,Observational,Terrestrial,Sub-national,,north america,United States
-24619,Loveridge_etal,2017,Observational,Terrestrial,Sub-national,500,africa,Zimbabwe
-24620,Loveridge_etal,2020,Observational,Terrestrial,Sub-national,,africa,Zimbabwe
-24622,Lozano_etal,2017,Observational,Freshwater,Continental,,south america,Unknown
-24624,Lucifora_etal,2016,Observational,Freshwater,Multi-national,0.5,south america,Brazil
-24627,Luizza_etal,2016,Observational,Freshwater,Sub-national,,north america,United States
-24628,Lunn and Moreau,2004,Observational,Marine,Sub-national,,south china sea,Indonesia
-24633,Lyon_etal,2011,Observational,Terrestrial,Local,100,europe,Finland
-24636,Macdonald_etal,2013,Observational,Terrestrial,Global,1,Unknown,Unknown
-24642,Mach_etal,2017,Observational,Marine,Sub-national,,north pacific,United States
-24646,Maclean_etal,2014,Observational,Freshwater,Multi-national,4,africa,DRC
-24648,Macnearney_etal,2016,Observational,Terrestrial,Sub-national,,north america,Canada
-24654,Magioli_etal,2019,Observational,Terrestrial,Local,,south america,Brazil
-24655,Magliozzi_etal,2020,Observational,Freshwater,Continental,100,europe,Unknown
-24656,Magness_etal,2011,Observational,Terrestrial,National,,north america,United States
-24659,Magris_etal,2019,Observational,Freshwater,Sub-national,,south atlantic,Brazil
-24660,Mahmood_etal,2019,Observational,Terrestrial,Sub-national,,asia,Pakistan
-24661,Mahmoud_etal,2019,Observational,Terrestrial,Sub-national,60,africa,Cameroon
-24663,Maiorano_etal,2019,Observational,Terrestrial,Sub-national,,europe,Italy
-24667,Malavasi_etal,2016,Observational,Terrestrial,Sub-national,,europe,Italy
-24673,Malherbe_etal,2019,Observational,Terrestrial,Local,,africa,South Africa
-24674,Mali?-Limari_etal,2017,Observational,Terrestrial,National,50,europe,Croatia
-24676,Malik and Rai,2019,Observational,Freshwater,Sub-national,,asia,India
-24677,Malinowski,2019,Observational,Marine,Sub-national,,north atlantic,United States
-24682,Manenti_etal,2014,Observational,Freshwater,Local,,europe,Italy
-24692,Mao_etal,2018,Observational,Freshwater,National,,asia,China
-24693,Marega-Imamura_etal,2020,S_Review,Marine,National,,south atlantic,Brazil
-24694,Marignani_etal,2017,Observational,Marine,Multi-national,1,mediterranean,France
-24695,Markham and Sangermano,2018,Observational,Freshwater,Local,,south america,Peru
-24696,Marotta_etal,2011,Observational,Marine,Sub-national,,mediterranean,Italy
-24698,Marques_etal,2019,Observational,Terrestrial,Local,100,europe,Spain
-24699,Márquez_etal,2013,Observational,Terrestrial,Sub-national,,europe,Spain
-24700,Martin_etal,2009,Observational,Marine,Sub-national,25,north atlantic,United Kingdom
-24705,Martínez-Freiría and Brito,2012,Observational,Terrestrial,Local,100,europe,Spain
-24706,Martinez-Gutierrez and Ruiz-Saenz,2016,S_Review,Terrestrial,Global,,Unknown,Unknown
-24710,Martins_etal,2013,Observational,Marine,Sub-national,,south atlantic,Brazil
-24713,Martinuzzi_etal,2018,Observational,Terrestrial,Sub-national,1,south america,Argentina
-24716,Marzolf_etal,2018,Observational,Freshwater,Local,,north america,United States
-24717,Maseko_etal,2017,Observational,Terrestrial,Sub-national,,africa,South Africa
-24718,Masocha and Dube,2018,Observational,Terrestrial,Global,,Unknown,Unknown
-24720,Mateo-Tomás_etal,2012,Observational,Terrestrial,Sub-national,1,europe,Spain
-24723,"Mati Bancy, M.",2005,Observational,Terrestrial,Multi-national,,africa,Kenya
-24728,Mazaris,2017,Observational,Marine,Global,,Unknown,Unknown
-24730,Mazor_etal,2017,Observational,Marine,National,0.01,south pacific,Australia
-24736,Mccauley_etal,2013,Observational,Terrestrial,Sub-national,,north america,United States
-24739,Mcclanahan,2015,Observational,Marine,Multi-national,,indian ocean,Comoros
-24740,Mcclanahan and Muthiga,2017,Observational,Marine,National,,indian ocean,Mozambique
-24738,Mcclanahan_etal,2011,Observational,Marine,Multi-national,,indian ocean,Comoros
-24742,Mcclellan,2009,Observational,Marine,Sub-national,,north atlantic,United States
-24741,Mcclellan_etal,2009,Observational,Marine,Sub-national,,north atlantic,United States
-24743,Mcclintock_etal,2015,Observational,Terrestrial,Sub-national,,north america,United States
-24745,Mccullough_etal,2017,Observational,Terrestrial,Sub-national,,north america,United States
-24747,Mccune_etal,2019,Observational,Freshwater,National,100,north america,Canada
-24748,Mcdonald_etal,2008,Observational,Terrestrial,Global,,Unknown,Unknown
-24750,Mcfadden-Hiller_etal,2016,Observational,Terrestrial,Sub-national,250,north america,United States
-24752,Mcgowan_etal,2013,Observational,Marine,Local,,north pacific,United States
-24754,Mcintyre_etal,2016,Observational,Freshwater,Global,100,Unknown,Unknown
-24761,Meager_etal,2012,Observational,Terrestrial,Local,0.25,australasia,Australia
-24765,Meentemeyer_etal,2011,Observational,Terrestrial,Local,250,north america,United States
-24766,Mehri_etal,2019,Observational,Freshwater,Sub-national,30,asia,Iran
-24769,Meijaard_etal,2011,Observational,Terrestrial,Sub-national,,asia,Indonesia
-24772,Mellin_etal,2016,Observational,Marine,Continental,81,indian ocean,Unknown
-24773,Mellin_etal,2019,Observational,Marine,Sub-national,0.01,south pacific,Australia
-24776,Menegon_etal,2018,Observational,Marine,Multi-national,500,mediterranean,Italy
-24777,Menegon_etal,2018,Observational,Marine,Sub-national,400,mediterranean,Italy
-24785,Metzger_etal,2010,Observational,Terrestrial,Sub-national,25,africa,Tanzania
-24788,Meynecke and Meager,2016,Observational,Marine,Sub-national,,south pacific,Australia
-24789,Mezgebu and Workineh,2017,Observational,Terrestrial,Local,30,africa,Ethiopia
-24790,Micheli_etal,2013,Observational,Marine,Multi-national,1,mediterranean,Bosnia and Herzegovina
-24796,Mijele_etal,2013,Observational,Terrestrial,Local,,africa,Kenya
-24806,Milne_etal,2015,Observational,Terrestrial,Sub-national,0.5,africa,South Africa
-24811,Miranda_etal,2020,Observational,Terrestrial,Sub-national,,south america,Chile
-24812,Miranda_etal,2020,Observational,Terrestrial,Local,,south america,Brazil
-24813,Mirrasooli_etal,2019,Observational,Marine,Multi-national,,caspian sea,Iran
-24819,Mo_etal,2017,Observational,Terrestrial,Sub-national,m,asia,China
-24821,Mockrin_etal,2008,Observational,Terrestrial,Local,,africa,Congo
-24822,Mockrin_etal,2011,Observational,Terrestrial,Local,,africa,Congo
-24825,Mohammadi and Kaboli,2016,Observational,Terrestrial,Local,,asia,Iran
-24826,Mohammadi_etal,2018,Observational,Terrestrial,Local,30,asia,Iran
-24829,Mojica_etal,2016,Observational,Terrestrial,Sub-national,1,north america,United States
-24832,Molinario_etal,2020,Observational,Terrestrial,Sub-national,30,africa,DRC
-24839,Monahan and Fisichelli,2014,Observational,Terrestrial,National,,north america,United States
-24842,Mondal and Zhang,2018,Observational,Terrestrial,Sub-national,,asia,India
-24841,Mondal_etal,2017,Observational,Freshwater,Local,,asia,India
-W26572,Moneron_etal,2017,Observational,Terrestrial,Global,,africa,Unknown
-24843,Monette Dean,2014,Observational,Freshwater,Local,,north america,United States
-24847,Monteiro_etal,2018,Observational,Terrestrial,Local,100,south america,Brazil
-24849,Montevecchi_etal,2012,Observational,Marine,Sub-national,,north atlantic,Canada
-24853,Moody_etal,2017,Observational,Freshwater,Sub-national,,north america,United States
-24856,Mora,2018,Observational,Terrestrial,National,1,north america,Mexico
-24857,Moraes_etal,2017,Observational,Terrestrial,Local,m,south america,Brazil
-24858,Moraes_etal,2019,Observational,Terrestrial,National,1,south america,Brazil
-24862,Moran and Kanemoto,2016,Observational,Freshwater,Global,,Unknown,Unknown
-24863,Moran_etal,2019,Observational,Freshwater,Global,5,Unknown,Unknown
-24867,Moreira_etal,2018,Observational,Terrestrial,Local,5,europe,Portugal
-24868,Morelli_etal,2020,Observational,Terrestrial,Continental,2500,europe,Unknown
-24871,Morgan_etal,2013,Observational,Terrestrial,Sub-national,,africa,Cameroon
-24875,Morrison_etal,2018,Experimental,Terrestrial,Local,30,africa,Kenya
-24877,Morton_etal,2011,Observational,Marine,Local,,north pacific,Canada
-24878,Mosbahi_etal,2019,Observational,Marine,Local,,mediterranean,Tunisia
-24879,Moullec_etal,2019,Observational,Marine,Multi-national,400,africa,Bosnia and Herzegovina
-24881,Mozumder_etal,2014,Observational,Freshwater,Local,,asia,India
-24885,Mucientes_etal,2009,Observational,Marine,Continental,5,north pacific,Unknown
-24886,Mucova_etal,2018,Observational,Terrestrial,Local,60,africa,Mozambique
-24888,Muhlfeld_etal,2016,Observational,Freshwater,Local,,north america,United States
-24892,Mullet_etal,2017,Observational,Terrestrial,Local,,north america,United States
-24894,Munanura_etal,2013,Observational,Terrestrial,Local,,africa,Rwanda
-24895,Munguía_etal,2016,Observational,Terrestrial,National,1,south america,Mexico
-24897,Muñoz_etal,2018,Observational,Marine,Multi-national,1,mediterranean,Spain
-24900,Munteanu_etal,2018,Observational,Terrestrial,Multi-national,2,europe,Austria
-24901,Murguía_etal,2016,Observational,Terrestrial,Global,,Unknown,Unknown
-26902,Murillo_et al,2008,Observational,Marine,Multi-national,,arctic ocean,Greenland
-24903,Murray_etal,2011,Observational,Freshwater,National,250,australasia,Australia
-24912,Mutnale_etal,2018,Observational,Freshwater,Multi-national,,asia,India
-24913,Mwendwa_etal,2020,Observational,Terrestrial,Local,,africa,Tanzania
-24917,Naderi_etal,2018,Observational,Terrestrial,National,,asia,Iran
-24902,Nagabhatla,2007,Observational,Freshwater,Global,500,asia,India
-24920,Nagarajan_etal,2016,Observational,Terrestrial,Local,,asia,India
-24929,Nath_etal,2019,Observational,Terrestrial,Local,1,asia,India
-24930,Naura_etal,2016,Observational,Freshwater,National,1,europe,United Kingdom
-24935,Nazaro_etal,2020,Observational,Terrestrial,Multi-national,441,south america,Argentina
-24937,Negret_etal,2019,Observational,Terrestrial,National,10,south america,Colombia
-24944,Nelson and Burnside,2019,Observational,Marine,Local,1,north atlantic,United Kingdom
-24943,Nelson_etal,2015,Observational,Terrestrial,Local,,north america,Canada
-24945,Nematollahi_etal,2020,Observational,Terrestrial,Sub-national,1,asia,Iran
-24951,Neumann_etal,2017,Observational,Marine,National,400,north atlantic,Germany
-24956,Newell,2011,Observational,Terrestrial,Local,,australasia,Australia
-24959,Nguyen,2017,Observational,Terrestrial,Local,0.5,asia,Brunei
-24962,Nickel Barry_etal,2020,Observational,Terrestrial,Local,1,north america,United States
-24963,Nielsen_etal,2004,Observational,Terrestrial,Sub-national,,north america,Canada
-24966,Nieman_etal,2019,Observational,Terrestrial,Local,,africa,South Africa
-24971,Niphadkar_etal,2017,Observational,Terrestrial,Local,2,asia,India
-24974,Nituch_etal,2011,Observational,Terrestrial,Sub-national,,north america,Canada
-24977,Noble_etal,2020,Observational,Marine,Local,,south pacific,Australia
-24978,Nogueira_etal,2010,Observational,Freshwater,National,,south america,Brazil
-24991,Northrup_etal,2019,Observational,Terrestrial,Sub-national,,north america,United States
-W26573,Nowell_etal,2016,Observational,Terrestrial,Multi-national,,asia,Afghanistan
-25005,O’leary_etal,2019,S_Review,Marine,Multi-national,,indian ocean,Gibraltar
-25008,Obusan_etal,2016,Observational,Marine,National,,south china sea,Philippines
-25010,Ochoa-Ochoa_etal,2011,Observational,Freshwater,National,,north america,Mexico
-25012,O'farrell_etal,2010,Observational,Terrestrial,Sub-national,,africa,South Africa
-25026,Ondei_etal,2019,Observational,Terrestrial,National,,australasia,Australia
-25028,Onmu? and Siki,2013,Observational,Freshwater,Local,1,asia,Turkey
-25030,Onyia_etal,2018,Experimental,Terrestrial,Local,,africa,Nigeria
-W26582,Opperman_etal,2019,Observational,Freshwater,Multi-national,,asia,Myanmar
-25033,Orgiazzi_etal,2016,Observational,Terrestrial,Continental,500,europe,Unknown
-25037,Ortiz Andrea,2019,Observational,Terrestrial,National,,asia,Philippines
-25042,Overmars_etal,2014,Observational,Freshwater,Continental,2500,europe,Unknown
-25049,Padalia and Bahuguna,2017,Observational,Terrestrial,Sub-national,km2,asia,India
-25051,Paffetti_etal,2018,Observational,Terrestrial,Local,1,europe,Italy
-25052,Pairaud_etal,2014,Observational,Marine,Multi-national,100,mediterranean,France
-25054,Palacios-Torres_etal,2020,Observational,Freshwater,Sub-national,,south america,Colombia
-25058,Paniw_etal,2015,Observational,Terrestrial,Multi-national,250,africa,Spain
-25059,Panlasigui_etal,2018,Observational,Freshwater,National,,north america,United States
-25061,Paredes_etal,2019,Observational,Freshwater,Local,,europe,Spain
-25065,Parmenter_etal,2003,Observational,Terrestrial,Sub-national,2.25,north america,United States
-25066,Parnell_etal,2010,Observational,Marine,Local,,north atlantic,United States
-25067,Parravicini_etal,2012,Observational,Marine,Local,250,mediterranean,Italy
-25068,Parry_etal,2009,Observational,Terrestrial,Local,,south america,Brazil
-25071,Parsons_etal,2014,Observational,Terrestrial,Local,,africa,Tanzania
-25072,Partelow_etal,2015,Observational,Marine,Global,,Unknown,Unknown
-25073,Paschoalini_etal,2020,Observational,Freshwater,Local,,south america,Brazil
-25075,Pascual-Rico_etal,2020,Observational,Terrestrial,Local,,europe,Spain
-25076,Pasha_etal,2020,Observational,Terrestrial,Sub-national,23.5,asia,India
-25077,Pasher_etal,2013,Observational,Terrestrial,Sub-national,30,north america,Canada
-25078,Pasqualini_etal,2011,Observational,Terrestrial,Local,,europe,France
-25080,Patino and Estupinan-Suarez,2016,Observational,Freshwater,National,100,south america,Colombia
-25082,Patrizzi and Dobrovolski,2018,Observational,Marine,National,5,north atlantic,Brazil
-25084,Pattanaik_etal,2011,Observational,Terrestrial,Local,80,asia,India
-25083,Pattanaik_etal,2008,Observational,Terrestrial,Local,57,asia,India
-25086,Patthey_etal,2008,Experimental,Terrestrial,Local,625,europe,Switzerland
-25088,Pauchard_etal,2003,Observational,Terrestrial,Local,,north america,United States
-25089,Paudel,2012,Observational,Terrestrial,Local,,asia,Nepal
-25099,Peck_etal,2011,Observational,Terrestrial,Sub-national,,south america,Ecuador
-25101,Pedroni ,2010,Observational,Terrestrial,Multi-national,,north america,Ecuador
-25112,Penney and Guinotte,2013,Observational,Marine,Sub-national,1,south pacific,New Zealand
-25114,Pennino_etal,2017,Observational,Marine,Sub-national,16,mediterranean,Italy
-25118,Peregrym_etal,2020,Observational,Marine,Multi-national,,mediterranean,Italy
-25120,Pereira_etal,2020,Observational,Terrestrial,Local,,south america,Brazil
-25122,Pérez-García_etal,2017,Observational,Terrestrial,Sub-national,1,europe,Spain
-25123,Périquet_etal,2018,Observational,Terrestrial,National,,africa,South Africa
-25124,Peristeraki_etal,2020,Observational,Marine,Multi-national,,mediterranean,Turkey
-25127,Pertierra_etal,2017,Observational,Terrestrial,National,2500,antarctica,Antarctica
-25130,Peterson_etal,2006,Observational,Terrestrial,Sub-national,,north america,United States
-25133,Petit and Elbersen,2006,Observational,Terrestrial,Continental,25,europe,Unknown
-25137,Petrossian,2015,Observational,Marine,Global,,Unknown,Unknown
-25138,Petrozzi_etal,2018,Observational,Terrestrial,Multi-national,100,africa,Algeria
-25139,Petz_etal,2014,Observational,Terrestrial,Global,30,Unknown,Unknown
-25145,Phipps_etal,2013,Observational,Terrestrial,Multi-national,,africa,Botswana
-25146,Phoenix_etal,2006,Observational,Terrestrial,Global,5,Unknown,Unknown
-25150,Pidgeon_etal,2015,Observational,Terrestrial,Multi-national,,south america,Bolivia
-25153,Pierre_etal,2018,Observational,Terrestrial,Sub-national,1,north america,United States
-25156,Pikesley_etal,2015,Observational,Marine,Multi-national,81,north atlantic,Cape Verde
-25157,Pikesley_etal,2016,Observational,Marine,Sub-national,200,north atlantic,United Kingdom
-25158,Pilcher_etal,2017,Observational,Marine,National,,south china sea,Thailand
-25159,Pilot_etal,2018,Observational,Terrestrial,Continental,,asia,Unknown
-25162,Pinho_etal,2018,Observational,Terrestrial,National,,europe,Portugal
-25165,Pinto_etal,2020,Observational,Terrestrial,Continental,10000,south america,Unknown
-25166,Piqueray_etal,2008,Observational,Terrestrial,National,,europe,Belgium
-25169,Pirotta_etal,2018,Observational,Marine,Sub-national,30,arctic ocean,Canada
-25172,Pitman_etal,2015,Observational,Terrestrial,Sub-national,,africa,South Africa
-25175,Plaza_etal,2019,Observational,Terrestrial,Global,,Unknown,Unknown
-25178,Plumptre_etal,2014,Observational,Terrestrial,Multi-national,62500,africa,Burundi
-25182,Polaina_etal,2016,Observational,Terrestrial,Global,1,Unknown,Unknown
-25188,Ponnampalam_etal,2015,Observational,Marine,Local,,south china sea,Malaysia
-25189,Pontius_etal,2008,Observational,Terrestrial,Sub-national,1,north america,United States
-25190,Poor_etal,2019,Observational,Terrestrial,Local,30,asia,Indonesia
-25191,Poos_etal,2010,Observational,Freshwater,Sub-national,,north america,Canada
-25193,Porobic_etal,2019,Observational,Marine,Sub-national,,south pacific,Chile
-25200,Potter_etal,2019,Observational,Terrestrial,National,,north america,United States
-25211,Preece,2007,Observational,Terrestrial,Local,500,australasia,Australia
-25216,Pretorius_etal,2019,Observational,Terrestrial,Sub-national,,africa,South Africa
-25221,Price_etal,2011,Observational,Freshwater,Sub-national,,north america,Canada
-25223,Proctor_etal,2015,Observational,Terrestrial,Sub-national,,north america,Canada
-25225,Prosser_etal,2016,Observational,Terrestrial,National,1,asia,China
-25229,Pullanikkatil_etal,2016,Observational,Freshwater,Local,,africa,Malawi
-25230,Pullanikkatil_etal,2020,Observational,Freshwater,Local,,africa,Malawi
-25232,Pupina_etal,2018,Observational,Freshwater,National,arc-minutes,europe,Latvia
-25233,Purroy_etal,2014,Observational,Marine,Local,500,mediterranean,Spain
-25234,Pusparini_etal,2018,Observational,Terrestrial,Local,,asia,Indonesia
-25240,Qiuqin and Tianzhu,2018,Observational,Terrestrial,Local,,asia,China
-25241,Qu_etal,2018,Observational,Terrestrial,Sub-national,1,asia,China
-25242,Quadroni_etal,2017,Observational,Freshwater,Local,,europe,Italy
-25246,Queiroz_etal,2016,Observational,Marine,Global,1,Unknown,Unknown
-25247,Queiroz_etal,2019,Observational,Marine,Global,1,Unknown,Unknown
-25266,Rahman_etal,2020,S_Review,Freshwater,Continental,,asia,Unknown
-25268,Raimondo_etal,2019,Observational,Freshwater,Sub-national,,north america,United States
-25270,Rajah_etal,2020,Observational,Terrestrial,Local,20,africa,South Africa
-25274,Ramachandra_etal,2016,Observational,Terrestrial,Sub-national,,asia,India
-25275,Ramachandra_etal,2018,Observational,Terrestrial,Local,,asia,India
-25276,Ramachandran_etal,2018,Observational,Terrestrial,Sub-national,,asia,India
-25278,Ramirez_etal,2018,Observational,Marine,Multi-national,0.25,mediterranean,Bosnia and Herzegovina
-25283,Ramirez-Villegas_etal,2012,Observational,Terrestrial,Continental,0.5,south america,Unknown
-25286,Ramos-Merchante and Prenda,2018,Observational,Freshwater,Sub-national,,europe,Spain
-25287,Ramp_etal,2006,Observational,Terrestrial,Local,300,australasia,Australia
-25292,Rao and Pant,2001,Observational,Freshwater,Local,,asia,India
-25296,Rashid_etal,2013,Observational,Terrestrial,Sub-national,,asia,India
-25297,Rashid_etal,2020,Observational,Terrestrial,Local,30,asia,Bangladesh
-25298,Rashidi_etal,2016,Observational,Terrestrial,Sub-national,,africa,Kenya
-25299,Rasmussen_etal,2013,Observational,Freshwater,Local,,europe,Denmark
-W26590,Ratsimbazafy_etal,2016,Observational,Marine,Local,,indian ocean,Madagascar
-25304,Rattner_etal,2000,S_Review,Terrestrial,Sub-national,,north atlantic,United States
-25308,Rayan and Linkie,2015,Observational,Terrestrial,Local,4,asia,Malaysia
-25309,Razgour_etal,2018,Observational,Terrestrial,Multi-national,1,europe,United Kingdom
-25313,Reddy_etal,2014,Observational,Terrestrial,Sub-national,25,asia,India
-25315,Redfern_etal,2012,Observational,Marine,Sub-national,4,north pacific,United States
-25317,Reece_etal,2013,Observational,Terrestrial,Local,,north atlantic,United States
-25324,Reina-Rodríguez and Soriano,2008,Observational,Marine,Local,,mediterranean,Spain
-25327,Reisland and Lambert,2016,Observational,Terrestrial,Local,,asia,Indonesia
-25336,Revuelta_etal,2018,Observational,Marine,Local,,mediterranean,Spain
-25337,Rey_etal,2015,Observational,Freshwater,National,,europe,France
-25350,Ribeiro and Sá-Sousa,2018,Observational,Terrestrial,Local,,europe,Portugal
-25349,Ribeiro_etal,2018,Observational,Freshwater,Sub-national,30,south america,Brazil
-25352,Ribeiro_etal,2019,Observational,Terrestrial,Sub-national,,south america,Brazil
-25355,Richards and Friess,2016,Observational,Terrestrial,Multi-national,1,asia,Indonesia
-25361,Rifaie_etal,2015,Observational,Terrestrial,Sub-national,,asia,Indonesia
-25365,Rija_etal,2020,S_Review,Terrestrial,Global,,Unknown,Unknown
-25369,Rimal_etal,2018,Observational,Terrestrial,Local,,asia,Nepal
-25371,Riolo,2006,Observational,Marine,National,km,south pacific,American Samoa
-25372,Ripple_etal,2016,Observational,Terrestrial,Global,,Unknown,Unknown
-25374,Riskas_etal,2016,Observational,Marine,National,1,indian ocean,Australia
-W26588,Robert I. Mcdonald_etal,2018,Observational,Terrestrial,Global,,Unknown,Unknown
-25381,Robertson_etal,2004,Observational,Terrestrial,Multi-national,1,africa,South Africa
-25384,Robillard and Kerr,2016,Observational,Terrestrial,Sub-national,,north america,Canada
-25390,Roder_etal,2015,Observational,Terrestrial,Multi-national,30,africa,Namibia
-25392,Rodrigues_etal,2014,Observational,Terrestrial,Global,,Unknown,Unknown
-25391,Rodrigues_etal,2012,Observational,Terrestrial,Sub-national,,europe,Spain
-25393,Rodrigues_etal,2014,Observational,Terrestrial,National,1,europe,Spain
-25400,Rodriguez-Merino_etal,2017,Observational,Freshwater,Multi-national,5,europe,Spain
-25402,Rodríguez-Rodríguez and Bomhard,2012,Observational,Terrestrial,Global,1,Unknown,Unknown
-25405,Rodríguez-Teijeiro_etal,2009,Observational,Terrestrial,National,,europe,Spain
-25407,Roe_etal,2014,Observational,Marine,Continental,5,north pacific,Unknown
-25409,Roger_etal,2011,Observational,Terrestrial,Local,100,australasia,Australia
-25410,Roger_etal,2012,Observational,Terrestrial,Local,,australasia,Australia
-25411,Rogers_etal,2010,Observational,Terrestrial,National,km,africa,Madagascar
-25413,Román-Palacios and Valencia-Zuleta,2018,Observational,Freshwater,National,0.5,south america,Colombia
-25416,Romero-Muñoz_etal,2019,Observational,Terrestrial,Multi-national,1,south america,Bolivia
-25417,Romero-Muñoz_etal,2020,Observational,Terrestrial,Multi-national,1,south america,Argentina
-25419,Ropert-Coudert_etal,2019,Observational,Terrestrial,Local,,north america,Mexico
-25420,Rorabaugh_etal,2018,Observational,Freshwater,Sub-national,,north america,Mexico
-25422,Roscioni_etal,2013,Observational,Terrestrial,Local,,europe,Italy
-25431,Rowden_etal,2019,Observational,Marine,National,1,south pacific,New Zealand
-25435,Ruiz-Orejón_etal,2019,Observational,Marine,Sub-national,,mediterranean,Spain
-25437,Rushton_etal,2006,Observational,Terrestrial,Local,100,europe,United Kingdom
-25438,Russo_etal,2020,Observational,Terrestrial,National,,europe,Italy
-25442,Sainsbury_etal,2008,Observational,Terrestrial,National,,europe,United Kingdom
-25443,Saito_etal,2016,Observational,Terrestrial,Local,,asia,Japan
-25444,Sajeev and Subramanian,2003,Observational,Freshwater,Local,,asia,India
-25447,Sales Naiara_etal,2018,Observational,Freshwater,Sub-national,,south america,Brazil
-25449,Salgado_etal,2018,Observational,Marine,Sub-national,289,north pacific,United States
-25454,Samhouri and Levin,2012,Observational,Marine,Local,,north pacific,United States
-25461,Sanchez-Mercado_etal,2008,Observational,Terrestrial,Sub-national,20,south america,Venezuela
-25464,Sangil_etal,2013,Observational,Marine,Local,,north atlantic,Canary Islands
-25469,Santora_etal,2017,Observational,Marine,Sub-national,4500,north pacific,United States
-25470,Santora_etal,2020,Observational,Marine,Sub-national,25,north pacific,United States
-25473,Santos_etal,2013,Observational,Terrestrial,Local,m,europe,Portugal
-25474,Santos_etal,2013,Observational,Terrestrial,Sub-national,m,europe,Portugal
-25482,Scabin_etal,2011,Observational,Terrestrial,Local,,south america,Brazil
-25488,Scheele_etal,2019,Observational,Freshwater,Global,,Unknown,Unknown
-25487,Scheele_etal,2015,Observational,Freshwater,Local,,europe,Romania
-25493,Schinegger_etal,2013,Observational,Freshwater,Continental,,europe,Unknown
-25496,Schlacher_etal,2016,S_Review,Marine,Global,,Unknown,Unknown
-25499,Schmeller_etal,2007,Observational,Freshwater,Multi-national,,europe,France
-25507,Schuette_etal,2016,Observational,Terrestrial,Local,,africa,Kenya
-25511,Schurmann_etal,2020,Observational,Terrestrial,Local,,africa,Kenya
-25512,Schuyler_etal,2014,S_Review,Marine,Global,,Unknown,Unknown
-25513,Schwartz_etal,2010,Observational,Terrestrial,Sub-national,,north america,United States
-25515,Sciarretta_etal,2016,Observational,Terrestrial,Sub-national,,europe,Italy
-25516,Scolozzi and Geneletti,2011,Observational,Terrestrial,Local,,europe,Italy
-25518,Seabrook_etal,2011,Observational,Terrestrial,Sub-national,,australasia,Australia
-25520,Seidel_etal,2018,Observational,Terrestrial,Sub-national,,europe,Germany
-25521,Seidler_etal,2015,Observational,Terrestrial,Local,10,north america,United States
-25523,Seiler,2005,Observational,Terrestrial,Sub-national,,europe,Sweden
-25524,Seim_etal,2016,Observational,Terrestrial,Multi-national,,asia,Kyrgyzstan
-25525,Seimon_etal,2013,Observational,Terrestrial,Sub-national,,asia,China
-25526,Seimon_etal,2015,Observational,Freshwater,Multi-national,,africa,Tanzania
-25529,Selkoe_etal,2009,Observational,Marine,Sub-national,0.01,north pacific,Hawaii
-25530,Selman_etal,2013,Experimental,Freshwater,Local,,north america,United States
-25531,Selvalakshmi,2014,Observational,Terrestrial,Local,,asia,India
-25535,Semper-Pascual_etal,2020,Observational,Terrestrial,Sub-national,30,south america,Argentina
-25539,Senn Helen_etal,2019,Observational,Terrestrial,Sub-national,,europe,United Kingdom
-25542,Serieys_etal,2019,Observational,Terrestrial,Local,,africa,South Africa
-25543,Serra-Varela_etal,2017,Observational,Terrestrial,National,1,europe,Spain
-25551,Shalders_etal,2018,Observational,Marine,Sub-national,1500,indian ocean,Australia
-25559,Sharma_etal,2018,Observational,Terrestrial,Sub-national,,asia,Nepal
-25560,Sharma_etal,2020,Observational,Terrestrial,National,,asia,Nepal
-25565,Shester,2008,Observational,Marine,Local,0.0001,north pacific,Mexico
-25567,Shilling and Waetjen,2015,Observational,Terrestrial,Sub-national,,north america,United States
-25574,Short_etal,2018,Observational,Marine,Global,,Unknown,Unknown
-25575,Shrestha_etal,2019,Observational,Freshwater,Local,500,asia,India
-25577,Sieber_etal,2013,Observational,Terrestrial,Sub-national,,asia,Russia
-25582,Sigaud_etal,2020,Observational,Terrestrial,Local,,north america,Canada
-25585,Silcock_etal,2019,Observational,Terrestrial,Sub-national,,australasia,Australia
-25588,Silva_etal,2014,Observational,Terrestrial,Sub-national,,europe,Portugal
-25589,Silva_etal,2018,Observational,Terrestrial,Local,0.5,south america,Brazil
-25591,Silva_etal,2020,Observational,Terrestrial,Local,200,asia,Thailand
-25593,Silva-Rodríguez and Sieving,2012,Observational,Terrestrial,Multi-national,,south america,Chile
-25598,Simon_etal,2019,Observational,Freshwater,Local,,africa,South Africa
-25600,Singh_etal,2009,Observational,Terrestrial,Local,,asia,India
-25601,Singh_etal,2017,Observational,Terrestrial,Local,,asia,India
-25607,Sini_etal,2019,Observational,Marine,Sub-national,,mediterranean,Greece
-25614,Skaer,2015,Observational,Terrestrial,Sub-national,,north america,United States
-25618,Sloan_etal,2018,Observational,Terrestrial,Sub-national,,asia,Indonesia
-25619,Smeraldo_etal,2020,Observational,Terrestrial,National,,europe,Italy
-25628,Smith Joshua_etal,2020,Observational,Marine,Sub-national,100,south pacific,Australia
-25622,Smith_etal,2014,Observational,Terrestrial,Local,30,north america,United States
-25625,Smith_etal,2017,Observational,Terrestrial,Local,,north america,United States
-25629,Smolinski and Calkiewicz,2015,Observational,Marine,Sub-national,,north atlantic,Poland
-25630,Snyder_etal,2011,Observational,Terrestrial,Local,,north america,United States
-25633,Soh_etal,2014,Observational,Terrestrial,Local,,asia,China
-25636,Soiret_etal,2019,Observational,Terrestrial,Local,,africa,Ivory Coast
-25640,Songer,2006,Observational,Terrestrial,Sub-national,m,asia,Myanmar
-25642,Songhurst_etal,2016,Observational,Terrestrial,Local,,africa,Botswana
-25643,Sonricker_etal,2012,Observational,Freshwater,Global,,Unknown,Unknown
-25645,Soriano_etal,2019,Observational,Freshwater,Local,500,asia,Philippines
-25646,Soroye_etal,2020,Observational,Terrestrial,Continental,0.5,europe,Unknown
-25651,Sousa_etal,2019,Observational,Marine,Local,,north atlantic,Portugal
-25654,Spanowicz_etal,2020,Observational,Terrestrial,Multi-national,,north america,Canada
-25656,Spitzen-Van Der_etal,2016,Observational,Terrestrial,Multi-national,,europe,Germany
-25664,Stafford_etal,2017,S_Review,Terrestrial,Continental,,south america,Mexico
-25671,Steinke and Saito,2013,Observational,Freshwater,Multi-national,,south america,Brazil
-25674,Steizenmuller_etal,2010,Observational,Marine,Sub-national,,north atlantic,United Kingdom
-25676,Stelzenmuller_etal,2015,Observational,Marine,National,31,north atlantic,Germany
-25675,Stelzenmüller_etal,2009,Observational,Marine,Local,50,mediterranean,Spain
-25679,Stephens_etal,2016,Observational,Terrestrial,Continental,2500,north america,Unknown
-25680,Stephenson_etal,2017,Observational,Marine,Local,100,north atlantic,United Kingdom
-25682,Steven and Castley,2013,Observational,Terrestrial,Global,,Unknown,Unknown
-25684,Stewart_etal,2010,Observational,Marine,Continental,1,indian ocean,Unknown
-25686,Stock_etal,2018,Observational,Marine,Global,5,Unknown,Unknown
-25687,Stock_etal,2018,Observational,Marine,Sub-national,,north pacific,United States
-25688,Stoica_etal,2017,Observational,Terrestrial,Local,0.5,europe,Romania
-W26583,Stoner and Pervushina,2013,Observational,Terrestrial,Multi-national,,asia,India
-25692,Stortini_etal,2015,Observational,Marine,Sub-national,,north atlantic,Canada
-25695,Stroud_etal,2017,Observational,Terrestrial,Local,,north america,Bermuda
-25696,Strubbe_etal,2010,Observational,Terrestrial,National,5,europe,Belgium
-25697,Struebig_etal,2018,Observational,Terrestrial,Sub-national,,asia,Indonesia
-25709,Swan_etal,2017,Observational,Freshwater,Sub-national,,south america,Brazil
-25711,Swartz_etal,2010,Observational,Marine,Global,0.5,Unknown,Unknown
-W26581,Sylvia_etal,2019,Observational,Marine,Global,,Unknown,Unknown
-25712,Symes_etal,2018,Observational,Terrestrial,Sub-national,,asia,Indonesia
-25713,Syphard_etal,2007,Observational,Terrestrial,Sub-national,1,north america,United States
-25714,Syphard_etal,2009,Observational,Terrestrial,Multi-national,225,mediterranean,Spain
-25716,Syxaiyakhamthor_etal,2019,Observational,Terrestrial,Local,1,asia,Laos
-25717,Szabo_etal,2009,Observational,Terrestrial,Sub-national,0.5,australasia,Australia
-25724,Talukdar_etal,2020,Observational,Terrestrial,Local,30,asia,India
-25726,Tamario_etal,2019,Observational,Freshwater,Sub-national,,europe,Sweden
-25732,Tancell_etal,2016,Observational,Marine,National,,southern ocean,South Georgia and the South Sandwich Islands
-25734,Tapia-Armijos_etal,2017,Observational,Terrestrial,Sub-national,100,south america,Ecuador
-25737,Tarrant_etal,2013,Observational,Freshwater,National,,africa,South Africa
-25740,Taylor_etal,2018,Observational,Freshwater,Sub-national,,north america,United States
-25745,Tello_etal,2020,Observational,Terrestrial,Sub-national,100,europe,Spain
-25751,Thapa_etal,2017,Observational,Terrestrial,Local,5,asia,Nepal
-25753,Thaxter_etal,2019,Observational,Terrestrial,Multi-national,400,europe,United Kingdom
-25754,Thellmann_etal,2018,Observational,Terrestrial,Local,30,asia,China
-25755,Theodorakis_etal,2017,Observational,Terrestrial,Local,,north america,United States
-25757,Thiault_etal,2020,Observational,Marine,Sub-national,50,south pacific,Australia
-25761,Thiebot_etal,2014,Observational,Marine,Multi-national,,indian ocean,Australia
-25766,Thonfeld_etal,2020,Observational,Freshwater,Sub-national,30,africa,Tanzania
-25767,Thongmanivong_etal,2005,Observational,Terrestrial,Local,,asia,Laos
-25781,Tingley_etal,2019,Observational,Terrestrial,National,,australasia,Australia
-25784,To_etal,2017,Observational,Terrestrial,Multi-national,,africa,Benin
-25796,Tolotti_etal,2015,Observational,Marine,Multi-national,degrees,south atlantic,Brazil
-25798,Topp-Jorgensen_etal,2009,Observational,Terrestrial,Local,,africa,Tanzania
-25802,Tovar_etal,2012,Observational,Terrestrial,Local,,south america,Peru
-25803,Tracy_etal,2019,Observational,Terrestrial,Multi-national,100,north america,United States
-25806,Trebilco_etal,2011,Observational,Marine,Global,5,Unknown,Unknown
-25805,Trebilco_etal,2008,Observational,Marine,Sub-national,50,south pacific,Macquarie Island
-25808,Treves_etal,2006,Observational,Terrestrial,Multi-national,,africa,Uganda
-25813,Trew_etal,2019,Observational,Marine,National,16,north atlantic,Equatorial Guinea
-25820,Trochine_etal,2018,Observational,Freshwater,Continental,,europe,Unknown
-25821,Troia and Mcmanamay,2020,Observational,Freshwater,Sub-national,,north america,United States
-25824,Troy,2013,Observational,Terrestrial,Local,,north america,United States
-25826,Trull_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown
-25830,Tucker_etal,2018,Observational,Terrestrial,Global,1,Unknown,Unknown
-25833,Tulloch_etal,2020,Observational,Marine,Global,km2,Unknown,Unknown
-25832,Tulloch_etal,2020,Observational,Marine,National,0.5,south pacific,Australia
-25837,Tursi_etal,2018,Observational,Marine,Local,,mediterranean,Italy
-25838,Twumasi,2006,Observational,Freshwater,Sub-national,30,africa,Nigeria
-25846,Underwood_etal,2011,Observational,Terrestrial,Sub-national,m,north america,United States
-W26577,Uryu_etal,2008,Observational,Terrestrial,Sub-national,1000,asia,Indonesia
-25850,Vacchiano_etal,2018,Observational,Terrestrial,Local,1,europe,Italy
-25856,Valliere,2016,Observational,Terrestrial,Local,1,north america,United States
-25857,Valliere_etal,2020,Observational,Terrestrial,Local,km2,north america,United States
-25865,Van Den_etal,2018,Observational,Terrestrial,Local,,south america,Suriname
-25866,Van Der_etal,2018,Observational,Marine,Multi-national,,north atlantic,United Kingdom
-25874,Van_etal,2018,Observational,Terrestrial,Continental,,south america,Unknown
-25858,Van_etal,2015,Observational,Terrestrial,Multi-national,arc-minutes,africa,Benin
-25862,Van_etal,2015,Observational,Terrestrial,Multi-national,900,africa,Kenya
-25870,Van_etal,2017,Experimental,Terrestrial,Local,,north america,United States
-25875,Vanderlaan_etal,2009,Observational,Marine,Sub-national,5,north atlantic,United States
-25877,Vanderpost,2007,Observational,Terrestrial,Local,,africa,Botswana
-25878,Vangansbeke_etal,2017,Observational,Terrestrial,Local,,europe,Belgium
-25879,Vanthomme_etal,2017,Observational,Terrestrial,Local,25,africa,Gabon
-25880,Vardarman_etal,2018,Observational,Terrestrial,Local,,europe,Czech Republic
-25884,Vasapollo_etal,2019,Observational,Marine,Sub-national,,mediterranean,Italy
-25888,Vasilakis_etal,2016,Observational,Terrestrial,Multi-national,,europe,Bulgaria
-25889,Vasilakis_etal,2017,Observational,Terrestrial,Multi-national,,europe,Bulgaria
-25891,Vasyliuk_etal,2015,Observational,Terrestrial,National,,europe,Ukraine
-25892,Veach_etal,2017,Observational,Terrestrial,Global,1,Unknown,Unknown
-25894,Velado-Alonso_etal,2020,Observational,Terrestrial,National,100,europe,Spain
-25896,Velho_etal,2012,S_Review,Terrestrial,National,,asia,India
-25901,Vendramin_etal,2013,Observational,Marine,Sub-national,,mediterranean,Italy
-25903,Venegas-Li_etal,2019,Observational,Marine,Global,0.5,Unknown,Unknown
-25904,Venkataraman_etal,2002,Observational,Terrestrial,Sub-national,,asia,India
-25908,Vergara-Tabares_etal,2020,Observational,Terrestrial,Continental,0.5,africa,Unknown
-25911,Verones_etal,2017,Observational,Terrestrial,Global,12100,Unknown,Unknown
-25912,Versluijs_etal,2020,Experimental,Terrestrial,Sub-national,,europe,Sweden
-25913,Verutes_etal,2020,Observational,Marine,Multi-national,,south china sea,Malaysia
-25925,Vimal_etal,2012,Observational,Terrestrial,Sub-national,100,europe,France
-25926,Vinitpornsawar,2013,Observational,Terrestrial,Local,1,asia,Thailand
-25930,Visintin_etal,2018,Observational,Terrestrial,Sub-national,1,australasia,Australia
-25933,Vogel,2007,Experimental,Freshwater,Sub-national,,north america,United States
-25934,Vojar_etal,2017,Observational,Freshwater,Multi-national,,europe,Montenegro
-25936,Vörösmarty_etal,2010,Observational,Freshwater,Global,0.5,Unknown,Unknown
-25942,Wakeel_etal,2005,Observational,Terrestrial,Local,,asia,India
-25944,Walentowitz_etal,2019,Observational,Terrestrial,Local,500,europe,Spain
-25948,Walker_etal,2020,Observational,Terrestrial,Local,,north america,United States
-25952,Wallace_etal,2011,Observational,Marine,Global,,Unknown,Unknown
-25953,Wallace_etal,2013,Observational,Marine,Global,,Unknown,Unknown
-25957,Walston and Hartmann,2018,Observational,Terrestrial,Sub-national,90,north america,United States
-25959,Waltham and Sheaves,2015,Observational,Marine,Sub-national,,south pacific,Australia
-25960,Wamelink_etal,2013,Observational,Terrestrial,National,250,europe,Netherlands
-25970,Wang_etal,2017,Observational,Terrestrial,National,2.5,asia,China
-25973,Wanghe_etal,2020,Observational,Terrestrial,Sub-national,,asia,China
-25978,Wasser_etal,2008,Observational,Terrestrial,Multi-national,,africa,Angola
-25980,Watson_etal,2015,Observational,Terrestrial,Sub-national,,africa,Zambia
-25986,Weimerskirch_etal,2018,Observational,Marine,Continental,,indian ocean,Unknown
-25988,Weinzettel_etal,2018,Observational,Terrestrial,Global,,Unknown,Unknown
-25991,Weir_etal,2011,Observational,Marine,Local,,south atlantic,Angola
-25997,Wessels_etal,2000,Observational,Terrestrial,Sub-national,15,africa,South Africa
-25998,Wessels_etal,2003,Observational,Terrestrial,Sub-national,700,africa,South Africa
-26001,White,2018,Observational,Terrestrial,Sub-national,,south america,Brazil
-26002,Whitty,2016,Observational,Marine,Local,,south atlantic,Philippines
-26006,Wiemeyer_etal,2017,Observational,Terrestrial,Continental,,south america,Unknown
-26011,Wiley_etal,2011,Observational,Marine,Sub-national,,north atlantic,United States
-26214,Williams,2017,Observational,Marine,Sub-national,1,north pacific,Alaska
-26015,Williams and O'hara,2010,Observational,Marine,Sub-national,25,north pacific,Canada
-26017,Williams_etal,2014,Observational,Terrestrial,Continental,,africa,Unknown
-26016,Williams_etal,2011,Observational,Marine,Sub-national,25,north pacific,Canada
-26032,Winchell_etal,2012,Observational,Freshwater,Sub-national,,north america,United States
-26033,Winchell_etal,2014,Observational,Freshwater,Sub-national,,north america,United States
-26036,Winemiller_etal,2016,Observational,Freshwater,Multi-national,,africa,Brazil
-26042,Winters_etal,2017,Observational,Marine,Local,,mediterranean,Israel
-26044,Witt and Godley,2007,Observational,Marine,Multi-national,9,north atlantic,United Kingdom
-26047,Wittig_etal,2007,Observational,Terrestrial,National,,africa,Burkina Faso
-26049,Woinarski_etal,2018,Observational,Terrestrial,National,,australasia,Australia
-26050,Wolaver_etal,2018,Observational,Terrestrial,Sub-national,1,north america,United States
-W26585,Wong,2019,Observational,Terrestrial,Global,,Unknown,Unknown
-26053,Wong_etal,2018,Observational,Marine,Sub-national,,arctic ocean,Canada
-26054,Woodcock_etal,2013,Observational,Terrestrial,Sub-national,,asia,Malaysia
-26057,Wraith and Pickering,2019,Observational,Terrestrial,National,,australasia,Australia
-26060,Wu,2016,Observational,Terrestrial,National,0.5,asia,China
-26063,Wu_etal,2020,Observational,Terrestrial,Multi-national,30,asia,China
-W26574,Wwf,2016,Observational,Terrestrial,Multi-national,,asia,Myanmar
-W26575,Wwf,2017,Observational,Terrestrial,Sub-national,,asia,Indonesia
-W26580,Wwf,2016,Observational,Terrestrial,Local,,north america,Mexico
-W26578,Wwf,2014,Observational,Marine,National,,north pacific,Russia
-W26576,Wwf-Indonesia,2013,Observational,Terrestrial,Local,,asia,Indonesia
-26067,Wyatt_etal,2017,Observational,Marine,Sub-national,1,north atlantic,United States
-26068,Xavier Da_etal,2018,Observational,Terrestrial,Local,,south america,Argentina
-26074,Xofis and Poirazidis,2018,Observational,Terrestrial,Local,0.5,europe,Greece
-26076,Xu_etal,2016,Observational,Terrestrial,National,0.5,asia,China
-26078,Xu_etal,2019,Observational,Terrestrial,Sub-national,30,asia,China
-26080,Yackulic_etal,2011,Observational,Terrestrial,Continental,2500,africa,Unknown
-26081,Yadav_etal,2020,Observational,Terrestrial,Local,m,asia,India
-26084,Yang_etal,2017,Observational,Freshwater,Local,,asia,China
-26086,Yang_etal,2019,Observational,Terrestrial,Sub-national,30,asia,China
-26089,Ye_etal,2015,Observational,Terrestrial,Sub-national,30,asia,China
-26090,Yee and Barron,2010,Observational,Marine,Global,,Unknown,Unknown
-26092,Yin_etal,2020,Observational,Terrestrial,Sub-national,1,asia,China
-26094,Young_etal,2011,Observational,Terrestrial,Local,,north america,United States
-26096,Yu_etal,2001,Observational,Freshwater,Sub-national,,asia,China
-26098,Yu_etal,2020,Observational,Freshwater,Multi-national,1,asia,Uzbekistan
-26102,Yumnam_etal,2014,Observational,Terrestrial,Sub-national,100,asia,India
-26103,Zacharias and Gregr,2005,Observational,Marine,Sub-national,,north pacific,Canada
-26104,Zafra-Calvo_etal,2010,Observational,Terrestrial,Local,1,africa,Equatorial Guinea
-26111,Zampiglia_etal,2013,Observational,Freshwater,National,,europe,Italy
-26112,Zapata-Ríos_etal,2009,Observational,Terrestrial,Local,,south america,Ecuador
-26117,Zhai_etal,2012,Observational,Terrestrial,Local,10,asia,China
-26127,Zhang and Vincent,2019,Observational,Marine,Global,1,Unknown,Unknown
-26120,Zhang_etal,2007,Observational,Terrestrial,Local,30,asia,China
-26131,Zhao_etal,2020,Observational,Terrestrial,Sub-national,,asia,China
-26135,Zhu_etal,2019,Observational,Terrestrial,National,1,asia,China
-26137,Ziegler_etal,2016,Observational,Terrestrial,Multi-national,1,africa,Central African Republic
-26140,Zimkus_etal,2020,S_Review,Freshwater,Continental,1,africa,Unknown
-26141,Zingraff-Hamed_etal,2018,Observational,Freshwater,Local,,europe,Germany
-26142,Zomer_etal,2014,Observational,Terrestrial,Multi-national,1,asia,China
-26145,Žydelis_etal,2009,S_Review,Marine,Multi-national,,north atlantic,United Kingdom
+ArticleID,Authors,Year,Study_design,Ecoregion,Spatial_Scale,Spatial_res,Continent_Ocean,country_eez,Title
+25370,Rímalová_etal,2014,Observational,Freshwater,National,,europe,Czech Republic,Species-specific pattern of crayfish distribution within a river network relates to habitat degradation: implications for conservation
+23013,Abade_etal,2018,Observational,Terrestrial,Local,,africa,Tanzania,Spatial variation in leopard (Panthera pardus) site use across a gradient of anthropogenic pressure in Tanzania's Ruaha landscape
+23018,Abrahms_etal,2019,Observational,Marine,Local,0.1,north pacific,United States,Dynamic ensemble models to predict distributions and anthropogenic risk exposure for highly mobile species
+23019,Abram_etal,2015,Observational,Terrestrial,Local,1,asia,Indonesia,Mapping perceptions of species' threats and population trends to inform conservation efforts: The Bornean orangutan case study
+23020,Abreo_etal,2019,Observational,Marine,Sub-national,,south china sea,Philippines,Social media as a novel source of data on the impact of marine litter on megafauna: The Philippines as a case study
+23022,Acevedo_etal,2007,Observational,Terrestrial,Sub-national,1,europe,Spain,The Iberian ibex is under an expansion trend but displaced to suboptimal habitats by the presence of extensive goat livestock in central Spain
+23030,Adams and Setterfield,2015,Observational,Terrestrial,Sub-national,250,australasia,Australia,Optimal dynamic control of invasions: Applying a systematic conservation approach
+23046,Ahmad_etal,2015,Observational,Terrestrial,Local,,asia,India,"Assessment of land use/land cover change in Hirpora wildlife sanctuary, Kashmir"
+23047,Ahmadi_etal,2019,Observational,Terrestrial,Multi-national,1,asia,Azerbaijan,Extinction risks of a Mediterranean neo-endemism complex of mountain vipers triggered by climate change
+23061,Albouy_etal,2017,Observational,Marine,Global,1,Unknown,Unknown,Multifaceted biodiversity hotspots of marine mammals for conservation priorities
+23062,Albright_etal,2017,Observational,Terrestrial,Sub-national,0.125,north america,United States,Mapping evaporative water loss in desert passerines reveals an expanding threat of lethal dehydration
+23063,Alcaraz_etal,2015,Observational,Freshwater,Sub-national,10,europe,Spain,"Assessing population status of Parachondrostoma arrigonis (Steindachner, 1866), threats and conservation perspectives"
+23051,Al-Chokhachy_etal,2014,Observational,Freshwater,Local,,north america,Canada,Quantifying the Effectiveness of Conservation Measures to Control the Spread of Anthropogenic Hybridization in Stream Salmonids: a Climate Adaptation Case Study
+23064,Alexander and Waters,2000,Observational,Terrestrial,Local,,north america,Canada,The effects of highway transportation corridors on wildlife: a case study of Banff National Park
+23068,Alfred_etal,2010,Observational,Terrestrial,Sub-national,2.5,asia,Malaysia,"Summarizing spatial distribution density, movement patterns and food resources to study the impacts of logging and forest conversion on Orang-utan population"
+23071,Allan_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown,Recent increases in human pressure and forest loss threaten many Natural World Heritage Sites
+23072,Allan_etal,2019,Observational,Terrestrial,Global,30,Unknown,Unknown,Hotspots of human impact on threatened terrestrial vertebrates
+23073,Almeida_etal,2014,Observational,Freshwater,Sub-national,10,europe,United Kingdom,Time-series analysis of native and non-native crayfish dynamics in the Thames River Basin (south-eastern England)
+23074,Almodóvar_etal,2012,Observational,Freshwater,Local,,europe,Spain,Global warming threatens the persistence of Mediterranean brown trout
+23052,Al-Nasrawi_etal,2018,Observational,Terrestrial,Local,0.8,australasia,Australia,Geoinformatics vulnerability predictions of coastal ecosystems to sea-level rise in Southeastern Australia
+23080,Álvarez,2003,Observational,Terrestrial,National,,south america,Colombia,Forests in the time of violence: Conservation implications of the colombian war
+23082,Alvarez-Berastegui_etal,2014,Observational,Marine,Sub-national,300,mediterranean,Spain,Multidisciplinary rapid assessment of coastal areas as a tool for the design and management of marine protected areas
+23083,Alvarez-Berrios and Mitchell,2015,Observational,Terrestrial,Multi-national,250,south america,Brazil,Global demand for gold is another threat for tropical forests
+23085,Alvarez-Filip_etal,2019,Observational,Marine,Sub-national,,north atlantic,Mexico,A rapid spread of the stony coral tissue loss disease outbreak in the Mexican Caribbean
+23086,Alvarez-Romero_etal,2013,Observational,Marine,Sub-national,500,south pacific,Australia,A novel approach to model exposure of coastal-marine ecosystems to riverine flood plumes based on remote sensing techniques
+23087,Alves_etal,2014,Observational,Terrestrial,Multi-national,0.16,north america,Canada,The Potential Impact of White-Nose Syndrome on the Conservation Status of North American Bats
+25335,Amano_etal,2020,Observational,Terrestrial,Global,1,Unknown,Unknown,Responses of global waterbird populations to climate change vary with latitude
+23091,Ambastha_etal,2010,Observational,Terrestrial,Local,250,asia,India,"Spatial analysis of anthropogenic disturbances in mangrove forests of Bhitarkanika Conservation Area, India"
+23100,Andersen_etal,2020,Observational,Marine,National,2,north atlantic,Denmark,Relative impacts of multiple human stressors in estuaries and coastal waters in the North Sea–Baltic Sea transition zone
+W26591,Anderson_etal,2017,Observational,Marine,Local,,north atlantic,Belize,"The role of conservation volunteers in the detection, monitoring and management of invasive alien lionfish"
+23105,Andrade-Díaz_etal,2019,Observational,Terrestrial,Sub-national,,south america,Argentina,Expansion of the agricultural frontier in the largest South American Dry Forest: Identifying priority conservation areas for snakes before everything is lost
+23106,Andréfouët_etal,2015,Observational,Marine,Multi-national,30,south pacific,Cook Islands,Mass mortality events in atoll lagoons: Environmental control and increased future vulnerability
+23114,Anjos_etal,2018,Observational,Terrestrial,Continental,6,south america,Unknown,Measuring resilience and assessing vulnerability of terrestrial ecosystems to climate change in South America
+23117,Ansari and Golabi,2019,Observational,Terrestrial,Local,,asia,Iran,"Using Ecosystem Service Modeler (ESM) for Ecological Quality, rarity and Risk Assessment of the wild goat habitat, in the Haftad-Gholleh protected area"
+23128,Araújo and Wang,2015,Observational,Freshwater,Sub-national,,south america,Brazil,The dammed river dolphins of Brazil: Impacts and conservation
+23125,Araújo_etal,2008,Observational,Terrestrial,Continental,50,europe,Unknown,Exposure of European biodiversity to changes in human-induced pressures
+23135,Arkema_etal,2014,Observational,Marine,National,500,north atlantic,Belize,Assessing habitat risk from human activities to inform coastal and marine spatial planning: A demonstration in Belize
+23138,Armenteras_etal,2013,Observational,Terrestrial,Local,,south america,Colombia,"Landscape Dynamics in Northwestern Amazonia: An Assessment of Pastures, Fire and Illicit Crops as Drivers of Tropical Deforestation"
+23142,Arroyave_etal,2020,Observational,Terrestrial,National,,south america,Colombia,Multiplex networks reveal geographic constraints on illicit wildlife trafficking
+23146,Asharfi_etal,2020,Observational,Terrestrial,Local,20,asia,Iran,QUANTITATIVE ASSESSMENT OF FOREST ECOSYSTEM STRESS CAUSED BY CEMENT PLANT POLLUTION USING IN SITU MEASUREMENTS AND SENTINEL-2 SATELLITE DATA IN A PART OF THE UNESCO WORLD HERITAGE SITE
+23147,Ashcroft_etal,2009,Observational,Terrestrial,Local,ha,australasia,Australia,Climate change at the landscape scale: predicting fine-grained spatial heterogeneity in warming and potential refugia for vegetation
+23151,Asner_etal,2009,Observational,Terrestrial,Global,500,Unknown,Unknown,A contemporary assessment of change in humid tropical forests
+23150,Asner_etal,2008,Observational,Terrestrial,Local,3,north america,United States,Invasive species detection in Hawaiian rainforests using airborne imaging spectroscopy and LiDAR
+23154,Assuncao_etal,2019,Observational,Terrestrial,Sub-national,0.5,south america,Brazil,"The invasion of Artocarpus heterophyllus, jackfruit, in protected areas under climate change and across scales: from Atlantic Forest to a natural heritage private reserve"
+23155,Astiaso_etal,2013,Observational,Terrestrial,National,,europe,Italy,An estimation of urban fragmentation of natural habitats: Case studies of the 24 italian national parks
+23160,Atkore_etal,2020,Observational,Freshwater,Sub-national,,asia,India,Multiscale Investigation of Water Chemistry Effects on Fish Guild Species Richness in Regulated and Nonregulated Rivers of India's Western Ghats: Implications for Restoration
+23163,Aubrecht_etal,2008,Observational,Marine,Global,km,Unknown,Unknown,A global inventory of coral reef stressors based on satellite observed nighttime lights
+23164,Auerbach_etal,2014,Observational,Terrestrial,Sub-national,25,australasia,Australia,Informed actions: Where to cost effectively manage multiple threats to species to maximize return on investment
+23169,Avila_etal,2018,S_Review,Marine,Global,0.5,Unknown,Unknown,Current global risks to marine mammals: Taking stock of the threats
+23170,Awkerman_etal,2016,Observational,Marine,Local,90,north atlantic,United States,Spatially explicit assessment of estuarine fish after Deepwater Horizon oil spill: Trade-off in complexity and parsimony
+23171,Ayele_etal,2016,Observational,Terrestrial,Local,30,africa,Ethiopia,"Multitemporal land use/land cover change detection for the batena watershed, rift valley lakes basin, Ethiopia"
+23177,Bacigalupe_etal,2019,Observational,Terrestrial,National,1,south america,Chile,The amphibian-killing fungus in a biodiversity hotspot: identifying and validating high-risk areas and refugia
+23185,Bahaa-El-Din_etal,2016,Observational,Terrestrial,Local,,africa,Gabon,Effects of human land-use on Africa's only forest-dependent felid: The African golden cat Caracal aurata
+23188,Baig and Aldosari,2012,Observational,Terrestrial,Local,,asia,Pakistan,An investigation into the vanishing biodiversity: Implications for rural extension
+23190,Bailey_etal,2017,Observational,Terrestrial,Sub-national,25,north america,United States,Impact of land use and climate on the distribution of the endangered Florida bonneted bat
+23196,Balasingham_etal,2018,Observational,Freshwater,Local,,north america,Canada,Environmental DNA detection of rare and invasive fish species in two Great Lakes tributaries
+23197,Baláž_etal,2014,Observational,Freshwater,Continental,,europe,Unknown,Assessing Risk and Guidance on Monitoring of Batrachochytrium dendrobatidis in Europe through Identification of Taxonomic Selectivity of Infection
+23200,Balotari-Chiebao_etal,2018,Observational,Terrestrial,National,25,europe,Finland,Assessing space use by pre-breeding white-tailed eagles in the context of wind-energy development in Finland
+23202,Balzotti_etal,2016,Observational,Terrestrial,Sub-national,,north america,United States,Beyond the single species climate envelope: A multifaceted approach to mapping climate change vulnerability
+23207,Bangs_etal,2018,Observational,Freshwater,Local,,north america,United States,Introgressive hybridization and species turnover in reservoirs: a case study involving endemic and invasive basses (Centrarchidae: Micropterus) in southeastern North America
+23211,Barbarossa_etal,2020,Observational,Freshwater,Global,,Unknown,Unknown,Impacts of current and future large dams on the geographic range connectivity of freshwater fish worldwide
+23222,Baret_etal,2006,Observational,Terrestrial,Local,500,africa,Mauritius,"Current distribution and potential extent of the most invasive alien plant species on La Réunion (Indian Ocean, Mascarene islands)"
+23223,Barilani_etal,2007,Observational,Terrestrial,Multi-national,,europe,France,Hybridisation with Introduced Chukars (Alectoris chukar) Threatens the Gene Pool Integrity of Native Rock (A. graeca) and Red-Legged (A. rufa) Partridge Populations
+23232,Barthelmess,2014,Observational,Terrestrial,Local,30,north america,United States,Spatial distribution of road-kills and factors influencing road mortality for mammals in Northern New York State
+23234,Bartolino_etal,2012,Observational,Marine,Sub-national,1369,north pacific,Alaska,Scale-dependent detection of the effects of harvesting a marine fish population
+23236,Bartz_etal,2015,Observational,Freshwater,Local,30,north america,United States,"Trends in developed land cover adjacent to habitat for threatened salmon in Puget Sound, Washington, U.S.A"
+23237,Barve_etal,2005,Observational,Terrestrial,Local,30,asia,India,Measuring and mapping threats to a wildlife sanctuary in southern India
+23242,Bass_etal,2010,Observational,Terrestrial,Sub-national,100,south america,Ecuador,Global conservation significance of Ecuador's Yasuní National Park
+23247,Battiston_etal,2012,Observational,Terrestrial,Local,0.5,europe,France,"Pleiades HR, a tool for biodiversity conservation: Case of common hamster on the Alsace Plain"
+23249,Bax_etal,2019,Observational,Terrestrial,Sub-national,,south america,Peru,Land-use conflicts between biodiversity conservation and extractive industries in the Peruvian Andes
+23252,Baynard_etal,2017,Observational,Terrestrial,Sub-national,1,north america,United States,Energy Development in Colorado’s Pawnee National Grasslands: Mapping and Measuring the Disturbance Footprint of Renewables and Non-Renewables
+23256,Beaudry_etal,2008,Observational,Terrestrial,Local,,north america,United States,Identifying road mortality threat at multiple spatial scales for semi-aquatic turtles
+23258,Bebbington_etal,2018,Observational,Terrestrial,Multi-national,,asia,Brazil,Resource extraction and infrastructure threaten forest cover and community rights
+23261,Becker and Zamudio,2011,Observational,Terrestrial,National,1,north america,Costa Rica,Tropical amphibian populations experience higher disease risk in natural habitats
+23262,Bedrosian_etal,2020,Observational,Terrestrial,Sub-national,1,north america,United States,"A Spatially Explicit Model to Predict the Relative Risk of Golden Eagle Electrocutions in the Northwestern Plains, USA"
+23266,Bejaoui_etal,2020,Observational,Freshwater,Local,,africa,Tunisia,Metal body burden and tissue oxidative status in the bivalve Venerupis decussata from Tunisian coastal lagoons
+23276,Bellard_etal,2016,Observational,Terrestrial,Global,10,Unknown,Unknown,Global patterns in threats to vertebrates by biological invasions
+23278,Belpaire_etal,2015,Observational,Freshwater,Sub-national,,europe,Belgium,Toxic textile dyes accumulate in wild European eel Anguilla anguilla
+23280,Ben Rais_etal,2016,Observational,Marine,Sub-national,0.1,mediterranean,Tunisia,Cumulative human threats on fish biodiversity components in Tunisian waters
+23282,Bendell and Wan,2011,Observational,Marine,Local,,north pacific,Canada,Application of aerial photography in combination with GIS for coastal management at small spatial scales: A case study of shellfish aquaculture
+23285,Bennett_etal,2010,Observational,Freshwater,Sub-national,,north america,Canada,Propagule pressure and stream characteristics influence introgression: Cutthroat and rainbow trout in British Columbia
+23290,Benslimane_etal,2019,Observational,Freshwater,Local,,africa,Algeria,Anthropogenic stressors are driving a steep decline of hemipteran diversity in dune ponds in north-eastern Algeria
+23293,Berthon_etal,2018,Observational,Terrestrial,National,1,australasia,Australia,Assessment and prioritisation of plant species at risk from myrtle rust (Austropuccinia psidii) under current and future climates in Australia
+23301,Bezeng_etal,2020,Observational,Terrestrial,National,1,africa,South Africa,Expected spatial patterns of alien woody plants in South Africa’s protected areas under current scenario of climate change
+23303,Bhatt_etal,2016,Observational,Freshwater,National,,asia,India,Assessing Potential Conservation and Restoration Areas of Freshwater Fish Fauna in the Indian River Basins
+23304,Bhola_etal,2012,Observational,Terrestrial,Local,25,africa,Kenya,The distribution of large herbivore hotspots in relation to environmental and anthropogenic correlates in the Mara region of Kenya
+23306,Bi_etal,2020,Observational,Marine,Multi-national,,north atlantic,United States,Long-term climate ocean oscillations inform seabird bycatch from pelagic longline fishery
+23313,Binothman,2016,Observational,Terrestrial,Sub-national,,asia,Saudi Arabia,Current Status of Falcon Populations in Saudi Arabia
+23315,Birkmanis_etal,2020,Observational,Marine,National,81,indian ocean,Australia,Shark conservation hindered by lack of habitat protection
+23318,Bisi_etal,2019,Observational,Terrestrial,Local,m,asia,Myanmar,Distribution of Wildlife and Illegal Human Activities in the Lampi Marine National Park (Myanmar)
+23330,Böhm_etal,2013,Observational,Marine,Global,7770,Unknown,Unknown,The conservation status of the world's reptiles
+23331,Böhm_etal,2016,Observational,Marine,Global,7770,Unknown,Unknown,Hot and bothered: Using trait-based approaches to assess climate change vulnerability in reptiles
+23337,Bonesi_etal,2007,Observational,Freshwater,Local,25,europe,United Kingdom,Trapping for mink control and water vole survival: Identifying key criteria using a spatially explicit individual based model
+23340,Borah_etal,2016,Observational,Terrestrial,Sub-national,100,asia,India,"Carnivores in corridors: estimating tiger occupancy in Kanha–Pench corridor, Madhya Pradesh, India"
+23343,Borrelli_etal,2015,Observational,Terrestrial,Local,500,south america,Colombia,The implications of fire management in the andean paramo: A preliminary assessment using satellite remote sensing
+23345,Bose_etal,2020,Observational,Terrestrial,Sub-national,100,europe,Germany,"Predicting strike susceptibility and collision patterns of the common buzzard at wind turbine structures in the federal state of Brandenburg, Germany"
+23350,Bouchard_etal,2015,Observational,Terrestrial,Local,,africa,South Africa,Undeclared baggage: Do tourists act as vectors for seed dispersal in fynbos protected areas?
+23353,Boulanger_etal,2014,Observational,Terrestrial,Sub-national,,north america,Canada,The impact of roads on the demography of grizzly bears in Alberta
+23355,Bourgoin_etal,2020,Observational,Terrestrial,Sub-national,10,asia,Thailand,Assessing the ecological vulnerability of forest landscape to agricultural frontier expansion in the Central Highlands of Vietnam
+23357,Bozkaya_etal,2015,Observational,Terrestrial,Local,30,asia,Turkey,Forecasting land-cover growth using remotely sensed data: a case study of the Igneada protection area in Turkey
+23361,Bradley,2010,Observational,Terrestrial,Sub-national,30,north america,United States,"Assessing ecosystem threats from global and regional change: Hierarchical modeling of risk to sagebrush ecosystems from climate change, land use and invasive species in Nevada, USA"
+23362,Bradley_etal,2020,Observational,Freshwater,Sub-national,,north america,United States,Exposure and potential effects of pesticides and pharmaceuticals in protected streams of the US National park Service southeast region
+23364,Braunisch_etal,2011,Observational,Terrestrial,Local,25,europe,Switzerland,Spatially explicit modeling of conflict zones between wildlife and snow sports: Prioritizing areas for winter refuges
+23365,Breen_etal,2017,Observational,Marine,Sub-national,48,north atlantic,United Kingdom,Where is the risk? Integrating a spatial distribution model and a risk assessment to identify areas of cetacean interaction with fisheries in the northeast Atlantic
+23368,Bright_etal,2008,Observational,Terrestrial,National,1,europe,United Kingdom,Map of bird sensitivities to wind farms in Scotland: A tool to aid planning and conservation
+23371,Briscoe_etal,2014,Observational,Terrestrial,Sub-national,1.44,asia,Malaysia,"Modeling habitat and bycatch risk for dugongs in Sabah, Malaysia"
+23374,Brito_etal,2018,Observational,Terrestrial,Multi-national,,africa,Mauritania,Armed conflicts and wildlife decline: Challenges and recommendations for effective conservation policy in the Sahara-Sahel
+23378,Bröker_etal,2015,Observational,Marine,Sub-national,1,north pacific,Russia,"Monitoring and impact mitigation during a 4D seismic survey near a population of gray whales off Sakhalin Island, Russia"
+23384,Brown and Hamilton,2018,Observational,Marine,Local,,south pacific,Solomon Islands,Estimating the footprint of pollution on coral reefs with models of species turnover
+23383,Brown_etal,2014,Observational,Marine,National,,indian ocean,Australia,Interactions between global and local stressors of ecosystems determine management effectiveness in cumulative impact mapping
+23390,Bruschi_etal,2015,Observational,Terrestrial,National,250,europe,Italy,Characterizing the fragmentation level of Italian's National Parks due to transportation infrastructures
+23391,Bryce_etal,2002,Observational,Terrestrial,Local,,europe,United Kingdom,Can niche use in red and grey squirrels offer clues for their apparent coexistence?
+23398,Buckland_etal,2014,Observational,Terrestrial,National,30,africa,Mauritius,Ecological Effects of the Invasive Giant Madagascar Day Gecko on Endemic Mauritian Geckos: Applications of Binomial-Mixture and Species Distribution Models
+23399,Buckley_etal,2016,Observational,Terrestrial,National,1,asia,China,How pristine are China's parks?
+23402,Buma_etal,2017,Observational,Terrestrial,Sub-national,,north america,United States,Emerging climate-driven disturbance processes: widespread mortality associated with snow-to-rain transitions across 10 degrees of latitude and half the range of a climate-threatened conifer
+23404,Bungnamei and Saikia,2020,Observational,Terrestrial,Local,60,asia,India,"PARK IN THE PERIPHERY: LAND USE AND LAND COVER CHANGE AND FOREST FRAGMENTATION IN AND AROUND YANGOUPOKPI LOKCHAO WILDLIFE SANCTUARY, MANIPUR, INDIA"
+23405,Burdett_etal,2010,Observational,Terrestrial,Sub-national,100,north america,United States,Interfacing models of wildlife habitat and human development to predict the future distribution of puma habitat
+23407,Burgess_etal,2016,Observational,Marine,Sub-national,90,north pacific,United States,Tracking diseases from terrestrial landscapes to kelp forests:Combining behavioural ecology and spatial epidemiology to understand pathogen movement in coastal ecosystems
+23409,Burivalova_etal,2020,Observational,Terrestrial,Sub-national,30,asia,Indonesia,Does biodiversity benefit when the logging stops? An analysis of conservation risks and opportunities in active versus inactive logging concessions in Borneo
+23412,Burton_etal,2012,Observational,Terrestrial,Local,500,africa,Ghana,"Hierarchical multi-species modeling of carnivore responses to hunting, habitat and prey in a West African protected area"
+23418,Butsic_etal,2015,Observational,Terrestrial,National,,africa,DRC,"Conservation and conflict in the Democratic Republic of Congo: The impacts of warfare, mining, and protected areas on deforestation"
+23424,Cadima_etal,2014,Observational,Terrestrial,National,5,south america,Bolivia,Endemic wild potato (Solanum spp.) biodiversity status in Bolivia: Reasons for conservation concerns
+23428,Callan_etal,2020,Observational,Terrestrial,Local,2.5,asia,China,Free-roaming dogs limit habitat use of giant pandas in nature reserves
+23429,Calle-Rendón_etal,2018,Observational,Terrestrial,National,0.1,south america,Colombia,Vulnerability of mammals to land-use changes in Colombia's post-conflict era
+23430,Calvert_etal,2005,Observational,Terrestrial,Sub-national,,north america,Canada,Spatiotemporal heterogeneity of greater snow goose harvest and implications for hunting regulations
+23438,Campana_etal,2018,Observational,Marine,Multi-national,25,mediterranean,Spain,Seasonal patterns of floating macro-litter across the Western Mediterranean Sea: a potential threat for cetacean species
+23448,Cao_etal,2020,Observational,Terrestrial,Sub-national,0.25,asia,China,"Ozone pollution in the west China rain zone and its adjacent regions, Southwestern China: Concentrations, ecological risk, and Sources"
+23449,Caorsi_etal,2014,Observational,Freshwater,Local,,south america,Brazil,"Natural history, coloration pattern and conservation status of the threatened South Brazilian red bellied toad, Melanophryniscus macrogranulosus Braun, 1973 (Anura, Bufonidae)"
+23452,Carassou_etal,2013,Observational,Marine,National,,south pacific,New Caledonia,Does Herbivorous Fish Protection Really Improve Coral Reef Resilience? A Case Study from New Caledonia (South Pacific)
+23454,Cardoso_etal,2018,Observational,Terrestrial,Sub-national,0.2,south america,Brazil,Anthropic Pressure on the Diversity of Cactaceae in a Region of Atlantic Forest in Eastern Brazil
+23456,Carle_etal,2019,Observational,Marine,Sub-national,,south pacific,Chile,Overlap of Pink-footed Shearwaters and central Chilean purse-seine fisheries: Implications for bycatch risk
+23461,Caro_etal,2020,Observational,Terrestrial,Sub-national,,africa,Tanzania,A case study of the coconut crab Birgus latro on Zanzibar highlights global threats and conservation solutions
+23464,Carrasco_etal,2020,Observational,Terrestrial,National,25,africa,Madagascar,Selecting priority areas for the conservation of endemic trees species and their ecosystems in Madagascar considering both conservation value and vulnerability to human pressure
+23466,Carrete_etal,2012,Experimental,Terrestrial,Sub-national,,europe,Spain,Mortality at wind-farms is positively related to large-scale distribution and aggregation in griffon vultures
+W26579,Carroll,2018,Observational,Terrestrial,Multi-national,,asia,Myanmar,Pulse of the Forest: The state of the Greater Mekong's Forests and the everyday people working to protect them
+23473,Carvajal-Quintero_etal,2017,Observational,Freshwater,Local,,south america,Colombia,Damming Fragments Species’ Ranges and Heightens Extinction Risk
+23477,Carvalho_etal,2019,Observational,Terrestrial,Sub-national,100,south america,Brazil,Changes in secondary vegetation dynamics in a context of decreasing deforestation rates in Pará Brazilian Amazon
+23487,Cavalcante,2012,Observational,Marine,Local,,north atlantic,Canada,"Study of Baleen Whales’ Ecology and Interaction with 
+Maritime Traffic Activities to Support Management of a 
+Complex Socio-Ecological System"
+23489,Ceballos-Mago_etal,2010,Observational,Terrestrial,National,,south america,Venezuela,Impact of the pet trade on the Margarita capuchin monkey Cebus apella margaritae
+23490,Ceia-Hasse_etal,2017,Observational,Terrestrial,Global,10000,Unknown,Unknown,Global exposure of carnivores to roads
+W26584,Chanchani P._etal,2014,Observational,Terrestrial,Multi-national,15,asia,India,"Tigers of the Transboundary Terai Arc Landscape: Status, distribution and movement in the Terai of India and Nepal. "
+W22911,Charity_etal,2016,Observational,Freshwater,Multi-national,,south america,Brazil,Living amazon report 2016: A regional approach to conservation in the Amazon
+23509,Chaudhary and Brooks,2019,Observational,Terrestrial,Global,,Unknown,Unknown,National Consumption and Global Trade Impacts on Biodiversity
+23507,Chaudhary and Kastner,2016,Observational,Terrestrial,Global,,Unknown,Unknown,Land use biodiversity impacts embodied in international food trade
+23508,Chaudhary_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown,Linking national wood consumption with global biodiversity and ecosystem service losses
+23513,Chaves_etal,2020,Observational,Freshwater,Local,,south america,Brazil,Pharmaceuticals and personal care products in a Brazilian wetland of international importance: Occurrence and environmental risk assessment
+23515,Chee_etal,2017,Observational,Terrestrial,Local,,indian ocean,Malaysia,Land reclamation and artificial islands: Walking the tightrope between development and conservation
+23517,Chen,2014,Observational,Terrestrial,Local,,asia,China,Spatial risk assessment of alien plants in China using biodiversity resistance theory
+23518,Chen and Koprowski,2015,Observational,Terrestrial,Local,50,north america,United States,Animal occurrence and space use change in the landscape of anthropogenic noise
+23523,Cheng,2017,Observational,Terrestrial,Sub-national,,north america,United States,"Long-Term Impacts of an Emerging Disease, White-Nose Syndrome: Drivers, Mechanisms, and Conservation Action Influencing the Persistence of North American Bats"
+23527,Chettri_etal,2013,Observational,Terrestrial,Local,,asia,Nepal,"Linking Spatio-temporal land cover change to biodiversity conservation in the koshi tappu wildlife reserve, Nepal"
+23528,Chevaldonné and Lejeusne,2003,Observational,Marine,Local,,mediterranean,France,Regional warming-induced species shift in north-west mediterranean marine caves
+23530,Chirichella_etal,2013,Observational,Terrestrial,Local,,europe,Italy,Effects of livestock and non-native mouflon on use of high-elevation pastures by Alpine chamois
+23531,Choe and Thorne,2019,Observational,Terrestrial,Multi-national,,asia,China,Climate exposure of East Asian temperate forests suggests transboundary climate adaptation strategies are needed
+23534,Choquette Jonathan_etal,2020,Observational,Terrestrial,Local,0.3,north america,Canada,Identifying Potential Connectivity for an Urban Population of Rattlesnakes (Sistrurus catenatus) in a Canadian Park System
+23537,Chowdhury and Maiti,2016,Observational,Freshwater,Local,,asia,India,"Assessing the ecological health risk in a conserved mangrove ecosystem due to heavy metal pollution: A case study from Sundarbans Biosphere Reserve, India"
+23543,Chu_etal,2003,Observational,Freshwater,National,,north america,Canada,Comparative regional assessment of factors impacting freshwater fish biodiversity in Canada
+23547,Chun_etal,2020,Observational,Terrestrial,National,1,asia,South Korea,Social big data informs spatially explicit management options for national parks with high tourism pressures
+23552,Chytry_etal,2009,Observational,Terrestrial,Continental,250,europe,Unknown,European map of alien plant invasions based on the quantitative assessment across habitats
+W26593,Cinner_etal,2018,Observational,Marine,Global,,Unknown,Unknown,Gravity of human impacts mediates coral reef conservation gains
+23559,Clare_etal,2019,Observational,Terrestrial,Local,250,north america,United States,Satellite-detected forest disturbance forecasts American marten population decline: The case for supportive space-based monitoring
+23560,Clark and Tittensor,2010,Observational,Marine,Global,1,Unknown,Unknown,An index to assess the risk to stony corals from bottom trawling on seamounts
+23565,Clarke_etal,2015,Observational,Marine,Sub-national,,north pacific,Canada,Cumulative effects of planned industrial development and climate change on marine ecosystems
+23566,Clarke_etal,2018,Observational,Marine,National,,north pacific,Costa Rica,"Assessing the vulnerability of demersal elasmobranchs to a data-poor shrimp trawl fishery in Costa Rica, Eastern Tropical Pacific"
+23571,Clavero and García-Berthou,2006,Observational,Freshwater,Multi-national,,europe,France,Homogenization dynamics and introduction routes of invasive freshwater fish in the Iberian Peninsula
+23572,Clavero_etal,2010,Observational,Freshwater,Multi-national,100,europe,Andorra,Geographical linkages between threats and imperilment in freshwater fish in the Mediterranean Basin
+23573,Clay_etal,2019,Observational,Marine,Global,5,Unknown,Unknown,A comprehensive large-scale assessment of fisheries bycatch risk to threatened seabird populations
+23576,Clements_etal,2014,Observational,Terrestrial,Local,1,asia,Malaysia,Where and how are roads endangering mammals in Southeast Asia's forests?
+23581,Codato_etal,2019,Observational,Terrestrial,Multi-national,,south america,Brazil,"Oil production, biodiversity conservation and indigenous territories: Towards geographical criteria for unburnable carbon areas in the Amazon rainforest"
+23582,Coll_etal,2012,Observational,Marine,Multi-national,0.1,mediterranean,Bosnia and Herzegovina,"The Mediterranean Sea under siege: Spatial overlap between marine biodiversity, cumulative threats and marine reserves"
+23583,Coll_etal,2015,Observational,Marine,Multi-national,0.1,mediterranean,Bosnia and Herzegovina,'Low-hanging fruit' for conservation of marine vertebrate species at risk in the Mediterranean Sea
+23588,Compa_etal,2019,Observational,Marine,Multi-national,0.2,mediterranean,Bosnia and Herzegovina,Risk assessment of plastic pollution on marine diversity in the Mediterranean Sea
+23591,Comte and Olden,2017,Observational,Freshwater,Global,0.1,Unknown,Unknown,Climatic vulnerability of the world's freshwater and marine fishes
+23594,Coppes and Braunisch,2013,Observational,Terrestrial,Local,10,europe,Germany,Managing visitors in nature areas: where do they leave the trails? A spatial model
+23595,Coppes_etal,2017,Observational,Terrestrial,Local,10,europe,Germany,Outdoor recreation causes effective habitat reduction in capercaillie Tetrao urogallus: a major threat for geographically restricted populations
+23598,Coristine and Kerr,2015,Observational,Terrestrial,Multi-national,5,north america,United States,Temperature-related geographical shifts among passerines: contrasting processes along poleward and equatorward range margins
+23599,Coristine_etal,2016,Observational,Terrestrial,Multi-national,5,north america,Canada,"Dispersal Limitation, Climate Change, and Practical Tools for Butterfly Conservation in Intensively Used Landscapes"
+23602,Correa_etal,2020,Observational,Terrestrial,National,300,south america,Colombia,Spatiotemporal evaluation of the human footprint in Colombia: Four decades of anthropic impact in highly biodiverse ecosystems
+23603,Cosandey-Godin_etal,2014,Observational,Marine,Sub-national,1,arctic ocean,Canada,Applying Bayesian spatiotemporal models to fisheries bycatch in the Canadian Arctic
+23609,Courtois_etal,2015,Observational,Terrestrial,National,,south america,French Guiana,"Widespread occurrence of Bd in French Guiana, South America"
+23612,Cowburn_etal,2018,Observational,Marine,National,,south atlantic,Comoros,"The current status of coral reefs and their vulnerability to climate change and multiple human stresses in the Comoros Archipelago, Western Indian Ocean"
+23613,Cowles_etal,2012,Observational,Freshwater,Sub-national,,north america,United States,Using GIS to assess pesticide exposure to threatened and Endangered Species for ecological risk assessment
+23614,Craig_etal,2019,Observational,Terrestrial,National,,africa,Namibia,The drivers and extent of poison use by Namibia’s communal farmers: Implications for averting the African vulture crisis
+23616,Crano,2016,Observational,Terrestrial,Local,10,north america,United States,Spatial assessment of ecosystem impacts from recreational trails in the San Bernardino National Forest
+23620,Critchell_etal,2019,Observational,Marine,Local,,south pacific,Australia,Predicting the exposure of coastal species to plastic pollution in a complex island archipelago
+23623,Croquer_etal,2016,Observational,Marine,Local,,north atlantic,Venezuela,"Is Acropora palmata recovering? A case study in Los Roques National Park, Venezuela"
+23626,Crosti_etal,2017,Observational,Marine,Local,,mediterranean,Italy,Assessing the relationship between cetacean strandings (Tursiops truncatus and Stenella coeruleoalba) and fishery pressure indicators in Sicily (Mediterranean Sea) within the framework of the EU Habitats Directive
+23631,Cubero-Pardo_etal,2011,Observational,Marine,Sub-national,22.2,north pacific,Mexico,A proposal to define vulnerability of cetacean areas to human development: Variables and analysis procedures applied to the gulf of California
+23633,Cuevas_etal,2019,Observational,Marine,Sub-national,1,north atlantic,Mexico,Ecological vulnerability of two sea turtle species in the Gulf of Mexico: An integrated spatial approach
+23639,Cunningham_etal,2013,Observational,Terrestrial,National,,africa,South Africa,Identifying biologically meaningful hot-weather events using threshold temperatures that affect life-history
+23641,Curatola_etal,2015,Observational,Terrestrial,Local,,south america,Ecuador,Land cover change in the Andes of southern Ecuador-Patterns and drivers
+23649,D’amico_etal,2019,Observational,Terrestrial,Multi-national,10,europe,Portugal,Bird collisions with power lines: Prioritizing species and areas by estimating potential population-level impacts
+23651,Dahdouh-Guebas_etal,2002,Observational,Terrestrial,Local,,indian ocean,Sri Lanka,Recent changes in land-use in the Pambala-Chilaw Lagoon complex (Sri Lanka) investigated using remote sensing and GIS: Conservation of mangroves vs. development of shrimp farming
+23652,Dalle_etal,2019,Observational,Terrestrial,Local,,south america,Brazil,Biodiversity responses to land-use and restoration in a global biodiversity hotspot: Ant communities in Brazilian Cerrado
+23653,Dalu_etal,2017,Observational,Freshwater,Local,,africa,Zimbabwe,Can Potamonautids be used as umbrella invertebrate species for conservation: Identifying opportunities and challenges related to community sustainable livelihoods
+23654,Daly_etal,2018,Observational,Marine,Multi-national,5,indian ocean,South Africa,Refuges and risks: Evaluating the benefits of an expanded MPA network for mobile apex predators
+23647,D'amico_etal,2015,Observational,Terrestrial,Local,,europe,Spain,"Vertebrate road-kill patterns in Mediterranean habitats: Who, when and where"
+23656,Dang_etal,2019,Observational,Terrestrial,Global,30,Unknown,Unknown,An analysis of the spatial association between deforestation and agricultural field sizes in the tropics and subtropics
+23657,Dang_etal,2020,Observational,Terrestrial,Sub-national,1,asia,China,Quantifying the Relative Importance of Climate Change and Human Activities on Selected Wetland Ecosystems in China
+23660,Darwall_etal,2011,Observational,Freshwater,Continental,,africa,Unknown,"The diversity of life in African freshwaters: underwater, under threat: an analysis of the status and distribution of freshwater species throughout mainland Africa"
+23663,Das_etal,2020,Observational,Freshwater,Local,,asia,India,Assessment of wetland ecosystem health using the pressure-state-response (PSR) model: A case study of Mursidabad District of West Bengal (India)
+23664,Dasgupta and Ghosh,2015,Observational,Terrestrial,Local,,asia,India,"Elephant–Railway Conflict in a Biodiversity Hotspot: Determinants and Perceptions of the Conflict in Northern West Bengal, India"
+23666,Dávalos_etal,2011,Observational,Terrestrial,National,1,south america,Colombia,Forests and drugs: Coca-driven deforestation in tropical biodiversity hotspots
+23669,De Abreu_etal,2011,Observational,Terrestrial,Local,,south america,Brazil,Changes in the plant community of a brazilian grassland savannah after 22 years of invasion by pinus elliottii engelm
+23670,De Alban_etal,2020,Observational,Terrestrial,Local,30,asia,Myanmar,Improved estimates of mangrove cover and change reveal catastrophic deforestation in Myanmar
+23674,De Castro_etal,2017,Observational,Terrestrial,Sub-national,km2,south america,Brazil,Impacts of mining activities on the potential geographic distribution of eastern Brazil mountaintop endemic species
+23682,De Luna_etal,2018,Observational,Terrestrial,Local,,south america,Colombia,"Distribution, population density and conservation of the critically endangered brown spider monkey (Ateles hybridus) and other primates of the inter-Andean forests of Colombia"
+23684,De Noronha_etal,2013,Observational,Terrestrial,Local,,europe,Portugal,"Regional challenges in tourist wetland systems: An integrated approach to the Ria Formosa in the Algarve, Portugal"
+23685,De Oliveira_etal,2020,Observational,Freshwater,Sub-national,25,south america,Brazil,"A multiscale analysis of land use dynamics in the buffer zone of Rio Doce State Park, Minas Gerais, Brazil"
+23689,De Solan_etal,2019,Observational,Terrestrial,Sub-national,1,europe,France,Opportunistic records reveal Mediterranean reptiles’ scale-dependent responses to anthropogenic land use
+23691,De Sousa_etal,2011,Observational,Freshwater,Local,,south america,Brazil,"Melanoides tuberculatus (Müller, 1774): a new threat to the conservation of native aquatic species in Sergipe, Brazil"
+23694,De Thoisy_etal,2010,Observational,Terrestrial,National,1,south america,French Guiana,Rapid evaluation of threats to biodiversity: Human footprint score and large vertebrate species responses in French Guiana
+23698,Death_etal,2019,Observational,Terrestrial,Local,,australasia,Australia,When less is more: a comparison of models to predict fluoride accumulation in free-ranging kangaroos
+23700,Deb_etal,2019,Observational,Terrestrial,Continental,1,asia,Unknown,Adaptive management and planning for the conservation of four threatened large Asian mammals in a changing climate
+23699,Deb_etal,2014,Observational,Terrestrial,Local,,asia,India,An alternative approach for delineating eco-sensitive zones around a wildlife sanctuary applying geospatial techniques
+23701,Deb_etal,2020,Observational,Terrestrial,Sub-national,,asia,India,Hazards of wind turbines on avifauna - A preliminary appraisal within the Indian context
+23704,Deith and Brodie,2020,Observational,Terrestrial,Sub-national,,asia,Malaysia,Predicting defaunation: Accurately mapping bushmeat hunting pressure over large areas
+23706,Delefosse_etal,2018,Observational,Marine,Sub-national,,north atlantic,Denmark,Marine mammal sightings around oil and gas installations in the central North Sea
+23710,Delsen,2020,Observational,Terrestrial,Continental,9,europe,Unknown,Threatened terrestrial vertebrates are exposed to human pressures across 94% of Europe's protected land
+23713,Deribew,2019,Observational,Terrestrial,Local,10,africa,Ethiopia,"Spatially explicit statistical modeling of random and systematic land cover transitions in the main grassland plain of Nech Sar National Park, Ethiopia"
+23714,Desta and Fetene,2020,Observational,Freshwater,Local,57,africa,Ethiopia,Land-use and land-cover change in Lake Ziway watershed of the Ethiopian Central Rift Valley Region and its environmental impacts
+23718,Deudero and Alomar,2015,S_Review,Marine,Multi-national,,mediterranean,Bosnia and Herzegovina,Mediterranean marine biodiversity under threat: reviewing influence of marine litter on species
+23726,Di_etal,2018,Observational,Terrestrial,Global,1,Unknown,Unknown,Changes in human footprint drive changes in species extinction risk
+23727,Di_etal,2019,Observational,Terrestrial,Global,30,Unknown,Unknown,Projecting impacts of global climate and land-use scenarios on plant biodiversity using compositional-turnover modelling
+23722,Di_etal,2019,Observational,Terrestrial,Continental,,europe,Unknown,Spatially explicit LCA analysis of biodiversity losses due to different bioenergy policies in the European Union
+23728,Di_etal,2013,Observational,Terrestrial,Sub-national,200,africa,South Africa,Conservation businesses and conservation planning in a biological diversity hotspot
+23730,Di_etal,2016,Observational,Marine,Local,1,south atlantic,Brazil,Identifying critical areas to reduce bycatch of coastal common bottlenose dolphins Tursiops truncatus in artisanal fisheries of the subtropical western South Atlantic
+23737,"Dignan, S.P.,",2014,Observational,Marine,Local,1,north atlantic,United Kingdom,Environmental impacts of demersal otter trawls targeting queen scallops (Aequipecten opercularis) in the Isle of Man territorial sea
+23738,Dillon Whalen_etal,2013,Observational,Terrestrial,Sub-national,1,north america,United States,Range-Wide Threats to a Foundation Tree Species from Disturbance Interactions
+23739,Dimitrakopoulos_etal,2017,Observational,Terrestrial,National,,europe,Greece,Factors shaping alien plant species richness spatial patterns across Natura 2000 Special Areas of Conservation of Greece
+23740,Dimobe_etal,2015,Observational,Terrestrial,Sub-national,30,africa,Sudan,"Identification of driving factors of land degradation and deforestation in the Wildlife Reserve of Bontioli (Burkina Faso, West Africa)"
+23743,Diwediga_etal,2015,Observational,Terrestrial,Local,,africa,Togo,Biophysical and anthropogenous determinants of landscape patterns and degradation of plant communities in Mo hilly basin (Togo)
+23744,Diwediga_etal,2017,Observational,Terrestrial,Multi-national,,africa,Burkina Faso,"Assessment of multifunctional landscapes dynamics in the mountainous basin of the Mo River (Togo, West Africa)"
+23753,Doherty,2008,Observational,Terrestrial,Sub-national,,north america,United States,Sage-grouse and energy development: Integrating science with conservation planning to reduce impacts
+23754,Doherty_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown,The global impacts of domestic dogs on threatened vertebrates
+23759,Dong_etal,2018,Observational,Terrestrial,National,,asia,China,GIS assessment of the risk of gene flow from Brassica napus to its wild relatives in China
+23760,Dorcas_etal,2012,Observational,Terrestrial,Local,,north america,United States,Severe mammal declines coincide with proliferation of invasive Burmese pythons in Everglades National Park
+23771,Dransfield_etal,2014,Observational,Marine,Local,1,north pacific,United States,Where the whales are: Using habitat modeling to support changes in shipping regulations within national marine sanctuaries in central California
+23773,Duan_etal,2020,Observational,Freshwater,National,30,asia,China,Using citizen science data to inform the relative sensitivity of waterbirds to natural versus human-dominated landscapes in China
+23779,Dulvy_etal,2014,Observational,Marine,Global,,Unknown,Unknown,Extinction risk and conservation of the world's sharks and rays
+23780,Duncan_etal,2014,Observational,Terrestrial,Multi-national,,africa,Algeria,Oil in the sahara: Mapping anthropogenic threats to saharan biodiversity from space
+23782,Duncan_etal,2018,Observational,Terrestrial,Multi-national,62.5,south atlantic,Bangladesh,Satellite remote sensing to monitor mangrove forest resilience and resistance to sea level rise
+23785,Duran,2008,Observational,Marine,Local,,north atlantic,Spain,A Case Study of available methodology for the identification of Vulnerable Ecosystems/Habitats in bottom deep-sea fisheries: Possibilities to apply this method in the NAFO Regulatory Area in order to select Marine Protected Areas
+23787,Durango-Cordero_etal,2018,Observational,Freshwater,Sub-national,25,south america,Ecuador,Spatial analysis of accidental oil spills using heterogeneous data: A case study from the North-Eastern Ecuadorian Amazon
+23788,Dutta_etal,2017,Observational,Terrestrial,Local,m,asia,India,"Assessing anthropogenic disturbance on forest health based on fragment grading in Durgapur Forest Range, West Bengal, India"
+23790,Duvall and Barron,2000,Experimental,Freshwater,Local,,north america,United States,A screening level probabilistic risk assessment of mercury in Florida Everglades food webs
+23791,Dwyer_etal,2016,Observational,Terrestrial,Sub-national,1,north america,United States,Power pole density informs spatial prioritization for mitigating avian electrocution
+23793,Dzialak_etal,2011,Observational,Terrestrial,Local,,north america,United States,Identifying and prioritizing greater sage-grouse nesting and brood-rearing habitat for conservation in human-modified landscapes
+23795,Easterday_etal,2016,Observational,Terrestrial,Sub-national,1,north america,United States,Assessing threats and conservation status of historical centers of oak richness in California
+23796,Ebdon_etal,2020,Observational,Marine,Sub-national,250,south pacific,New Zealand,"Testing the efficacy of ship strike mitigation for whales in the Hauraki Gulf, New Zealand"
+23804,Eguchi_etal,2017,Observational,Marine,Sub-national,0.5,north pacific,United States,Predicting overlap between drift gillnet fishing and leatherback turtle habitat in the California Current Ecosystem
+23816,Elleouet_etal,2014,Observational,Marine,Multi-national,0.1,mediterranean,Bosnia and Herzegovina,A trait-based approach for assessing and mapping niche overlap between native and exotic species: The mediterranean coastal fish fauna as a case study
+23823,Enrichetti_etal,2019,Observational,Marine,Multi-national,,mediterranean,Italy,"Assessing the environmental status of temperate mesophotic reefs: A new, integrated methodological approach"
+23824,Enríquez-Andrade_etal,2005,Observational,Marine,Sub-national,,north pacific,United States,An analysis of critical areas for biodiversity conservation in the Gulf of California Region
+23825,Epa and Mohotti,2016,Observational,Freshwater,Local,,asia,Sri Lanka,"Impact of fishing with Tephrosia candida (Fabaceae) on diversity and abundance of fish in the streams at the boundary of Sinharaja Man and Biosphere Forest Reserve, Sri Lanka"
+23828,Erbe_etal,2014,Observational,Marine,Sub-national,25,north pacific,Canada,Identifying modeled ship noise hotspots for marine mammals of Canada's Pacific region
+23832,Escobar_etal,2015,Observational,Terrestrial,Continental,21.16,asia,Unknown,Anthropogenic disturbance and habitat loss for the red-listed Asiatic black bear (Ursus thibetanus): Using ecological niche modeling and nighttime light satellite imagery
+23833,Esetlili_etal,2014,Observational,Terrestrial,Local,15,asia,Turkey,Relationship between highway constructions and natural habitat. a case study of izmir highway
+23836,Espinoza-Tenorio_etal,2010,Observational,Marine,Local,,north pacific,United States,Ecosystem-based analysis of a marine protected area where fisheries and protected species coexist
+23838,Esselman and Allan,2011,Observational,Freshwater,Multi-national,,north america,Mexico,Application of species distribution models and conservation planning software to the design of a reserve network for the riverine fishes of northeastern Mesoamerica
+23841,Estoque and Murayama,2012,Observational,Terrestrial,Local,30,asia,Philippines,"Examining the potential impact of land use/cover changes on the ecosystem services of Baguio city, the Philippines: A scenario-based analysis"
+23845,Etter_etal,2011,Observational,Terrestrial,National,1,south america,Colombia,Incorporating temporality and biophysical vulnerability to quantify the human spatial footprint on ecosystems
+23847,Evans_etal,2011,Observational,Terrestrial,National,,australasia,Australia,What to do in the face of multiple threats? Incorporating dependencies within a return on investment framework for conservation
+23848,Evans_etal,2011,Observational,Freshwater,National,,australasia,Australia,The spatial distribution of threats to species in Australia
+23854,Fa_etal,2013,Observational,Terrestrial,Multi-national,,africa,Cameroon,Mapping Hotspots of Threatened Species Traded in Bushmeat Markets in the Cross-Sanaga Rivers Region
+W26589,Fabian C. Kyne_etal,2020,Observational,Marine,Multi-national,,north atlantic,Anguilla,Managing invasive lionfish in Belize's Marine Protected Areas
+23855,Fabrizio_etal,2019,Observational,Terrestrial,Sub-national,40,europe,Italy,Where will it cross next? Optimal management of road collision risk for otters in Italy
+23856,Fabrizio_etal,2019,Observational,Terrestrial,Sub-national,1,europe,Italy,Habitat suitability vs landscape connectivity determining roadkill risk at a regional scale: a case study on European badger (Meles meles)
+23858,Fakarayi_etal,2015,Observational,Terrestrial,Local,,africa,Zimbabwe,"Pattern of land-use and land cover changes in driefontein grassland important bird area, Zimbabwe"
+23864,Farella_etal,2020,Observational,Marine,Local,250,mediterranean,Italy,Incorporating ecosystem services conservation into a scenario-based MSP framework: An Adriatic case study
+23865,Farfán_etal,2019,Observational,Terrestrial,Local,0.25,africa,Cameroon,"Spatial modelling for predicting potential wildlife distributions and human impacts in the Dja Forest Reserve, Cameroon"
+23866,Fargione_etal,2012,Observational,Terrestrial,Sub-national,200,north america,United States,Wind and wildlife in the Northern Great Plains: Identifying low-impact areas for wind development
+23867,Farizal_etal,2020,Observational,Terrestrial,Local,,asia,Indonesia,"Analysis of the Mount Tunggangan Wildlife Reserve Area Arrangement, Sragen, Central Java using Geographic Information Systems (GIS) with Ecological Sensitivity and Ecological Pressure Approaches"
+23868,Fasola and Roesler,2018,Observational,Terrestrial,Sub-national,2500,south america,Argentina,A familiar face with a novel behavior raises challenges for conservation: American mink in arid Patagonia and a critically endangered bird
+23869,Fassnacht_etal,2015,Observational,Terrestrial,Sub-national,30,asia,China,Mapping degraded grassland on the Eastern Tibetan Plateau with multi-temporal Landsat 8 data - where do the severely degraded areas occur?
+23870,Fauzi_etal,2019,Observational,Terrestrial,Multi-national,1,south china sea,Myanmar,Contextualizing Mangrove Forest Deforestation in Southeast Asia Using Environmental and Socio-Economic Data Products
+23871,Favilli_etal,2018,Observational,Terrestrial,Sub-national,,europe,Italy,"Application of KDE plus software to identify collective risk hotspots of ungulate-vehicle collisions in South Tyrol, Northern Italy"
+23877,Feist_etal,2011,Observational,Marine,Local,30,north pacific,United States,Landscape ecotoxicology of coho salmon spawner mortality in urban streams
+23879,Feitosa_etal,2018,Observational,Marine,Sub-national,,north atlantic,Brazil,DNA-based identification reveals illegal trade of threatened shark species in a global elasmobranch conservation hotspot
+23881,Felton Annika_etal,2013,Observational,Terrestrial,Multi-national,,south america,Bolivia,Commercial harvesting of Ficus timber–An emerging threat to frugivorous wildlife and sustainable forestry
+23888,Fernandes_etal,2017,Observational,Marine,National,25,north atlantic,Portugal,How does the cumulative impacts approach support Maritime Spatial Planning?
+23889,Fernandes_etal,2020,Observational,Marine,National,,north atlantic,Portugal,Mapping the future: Pressures and impacts in the Portuguese maritime spatial planning
+23891,Fernández-Bellon,2020,S_Review,Terrestrial,Global,,Unknown,Unknown,Limited accessibility and bias in wildlife-wind energy knowledge: A bilingual systematic review of a globally distributed bird group
+25210,Ferrarini_etal,2021,Observational,Terrestrial,Sub-national,,europe,Italy,Preserving the Mediterranean bird flyways: Assessment and prioritization of 38 main wetlands under human and climate threats in Sardinia and Sicily (Italy)
+23893,Ferreguetti Á_etal,2018,Observational,Terrestrial,Local,,south america,Brazil,One step ahead to predict potential poaching hotspots: Modeling occupancy and detectability of poachers in a neotropical rainforest
+23903,Filius_etal,2020,Observational,Terrestrial,Local,,south america,Ecuador,Wildlife roadkill patterns in a fragmented landscape of the Western Amazon
+23904,Findlay_etal,2018,Observational,Marine,Sub-national,25,north atlantic,United Kingdom,Mapping widespread and increasing underwater noise pollution from acoustic deterrent devices
+23905,Finer_etal,2008,Observational,Terrestrial,Multi-national,,south america,Brazil,"Oil and gas projects in the Western Amazon: Threats to wilderness, biodiversity, and indigenous peoples"
+23906,Fiorini_etal,2017,Observational,Terrestrial,Sub-national,,europe,Italy,Urban development of the coastal system of the Italian largest islands: Sicily and Sardinia
+23909,Flechas_etal,2017,Observational,Terrestrial,Sub-national,,south america,Colombia,"Current and predicted distribution of the pathogenic fungus Batrachochytrium dendrobatidis in Colombia, a hotspot of amphibian biodiversity"
+23912,Flory_etal,2012,Observational,Terrestrial,Sub-national,,north america,United States,Environmental conditions associated with bat white-nose syndrome mortality in the north-eastern United States
+23913,Floyd_etal,2006,Observational,Terrestrial,Local,,north america,United States,"Predicting and mitigating weed invasions to restore natural post-fire succession in Mesa Verde National Park, Colorado, USA"
+23915,Focardi_etal,2006,Observational,Freshwater,Multi-national,,africa,Kenya,Integrating remote sensing approach with pollution monitoring tools for aquatice ecosystem risk assessment and managment: A case study of Lake Victoria (UGANDA)
+23917,Foden_etal,2013,Observational,Freshwater,Global,1,Unknown,Unknown,"Identifying the World's Most Climate Change Vulnerable Species: A Systematic Trait-Based Assessment of all Birds, Amphibians and Corals"
+23920,Fonnesbeck_etal,2008,Observational,Marine,Local,16,north atlantic,United States,Bayesian hierarchichal model for evaluating the risk of vessel strikes on North Atlantic right whales in the SE United States
+23922,Foo and Numata,2019,Observational,Terrestrial,Local,30,asia,Malaysia,"Deforestation and forest fragmentation in and around Endau-Rompin National Park, Peninsular Malaysia"
+23927,Fort_etal,2013,Observational,Marine,Multi-national,,arctic ocean,Greenland,Multicolony tracking reveals potential threats to little auks wintering in the North Atlantic from marine pollution and shrinking sea ice cover
+23929,Fortini Lucas_etal,2019,Observational,Terrestrial,Sub-national,500,north america,United States,The evolving threat of Rapid ‘?hi ‘a Death (ROD) to Hawai ‘i’s native ecosystems and rare plant species
+23932,Foveau_etal,2017,Observational,Marine,Sub-national,0.03,north atlantic,United Kingdom,Process-driven and biological characterisation and mapping of seabed habitats sensitive to trawling
+23936,Foxcroft_etal,2007,Observational,Freshwater,Sub-national,,africa,South Africa,Risk assessment of riparian plant invasions into protected areas
+23937,Foxcroft_etal,2009,Observational,Freshwater,Sub-national,25,africa,South Africa,"Patterns of alien plant distribution at multiple spatial scales in a large national park: implications for ecology, management and monitoring"
+23938,Francesco_etal,2019,Observational,Terrestrial,Local,,europe,Italy,"Geographical Relationship between Ungulates, Human Pressure and Territory"
+23941,Fraschetti_etal,2016,Observational,Marine,Local,,mediterranean,Italy,Impact of offshore gas platforms on the structural and functional biodiversity of nematodes
+23946,Fremout_etal,2020,Observational,Terrestrial,Multi-national,30,south america,Ecuador,Mapping tree species vulnerability to multiple threats as a guide to restoration and conservation of tropical dry forests
+23951,Fryxell_etal,2020,Observational,Terrestrial,Sub-national,,north america,Canada,Anthropogenic Disturbance and Population Viability of Woodland Caribou in Ontario
+23953,Fuentes_etal,2016,Observational,Terrestrial,Sub-national,m,north atlantic,United States,Conservation hotspots for marine turtle nesting in the United States based on coastal development
+23955,Fugère_etal,2018,Observational,Freshwater,Local,,africa,Uganda,Ecosystem structure and function of afrotropical streams with contrasting land use
+23957,Furlan_etal,2018,Observational,Marine,Multi-national,100,mediterranean,Italy,Spatially explicit risk approach for multi-hazard assessment and management in marine environment: The case study of the Adriatic Sea
+23958,Furlan_etal,2019,Observational,Marine,Multi-national,,mediterranean,Italy,Cumulative Impact Index for the Adriatic Sea: Accounting for interactions among climate and anthropogenic pressures
+23960,Gabriel_etal,2012,Observational,Terrestrial,Sub-national,,north america,United States,Anticoagulant rodenticides on our public and community lands: Spatial distribution of exposure and poisoning of a rare forest carnivore
+23964,Gaines_etal,2005,Observational,Freshwater,Local,10,north america,United States,The development of a spatially explicit model to estimate radiocaesium body burdens in raccoons (Procyon lotor) for ecological risk assessment
+23967,Gairola_etal,2016,Observational,Terrestrial,Local,0.5,africa,South Africa,Remote sensing object-oriented approaches coupled with ecological informatics to map invasive plant species
+23968,Gaisberger_etal,2017,Observational,Terrestrial,Sub-national,2.5,africa,Burkina Faso,Spatially explicit multi-threat assessment of food tree species in Burkina Faso: A fine-scale approach
+23969,Gaisberger_etal,2020,Observational,Terrestrial,Multi-national,30,asia,Kyrgyzstan,Diversity Under Threat: Connecting Genetic Diversity and Threat Mapping to Set Conservation Priorities for Juglans regia L. Populations in Central Asia
+23977,Gallagher_etal,2019,Observational,Terrestrial,Continental,10000,australasia,Australia,Safety margins and adaptive capacity of vegetation to climate change
+23975,Gallagher_etal,2008,Observational,Terrestrial,Local,10,north america,United States,Soil metal concentrations and vegetative assemblage structure in an urban brownfield
+23978,Gallão and Bichuette,2018,Observational,Terrestrial,Sub-national,,south america,Brazil,Brazilian obligatory subterranean fauna and threats to the hypogean environment
+23979,Gallardo and Aldridge,2013,Observational,Freshwater,Continental,16,europe,Unknown,Evaluating the combined threat of climate change and biological invasions on endangered species
+23980,Gallardo_etal,2017,Observational,Freshwater,Continental,30,europe,Unknown,Protected areas offer refuge from invasive species spreading under climate change
+23982,Gallego-Zamorano_etal,2020,Observational,Terrestrial,Global,30,Unknown,Unknown,Combined effects of land use and hunting on distributions of tropical mammals
+23985,Gaoue and Ticktin,2007,Observational,Terrestrial,National,,africa,Benin,Patterns of harvesting foliage and bark from the multipurpose tree Khaya senegalensis in Benin: Variation across ecological regions and its impacts on population structure
+23988,Garcês_etal,2019,Observational,Terrestrial,Sub-national,,europe,Portugal,Preservation of wild bird species in northern Portugal - Effects of anthropogenic pressures in wild bird populations (2008–2017)
+23989,Garcia_etal,2014,Observational,Freshwater,Multi-national,1,africa,Angola,Matching species traits to projected threats and opportunities from climate change
+23991,García-Barcelona_etal,2010,Observational,Marine,Sub-national,,mediterranean,Spain,Modelling abundance and distribution of seabird by-catch in the Spanish mediterranean longline fishery
+23992,Garcia-Carrasco_etal,2020,Observational,Terrestrial,Local,,south america,Ecuador,Roadkill of birds in Galapagos Islands: a growing need for solutions
+23993,Garcia-De-Vinuesa_etal,2018,Observational,Marine,Local,1,mediterranean,Spain,Linking trawl fleet dynamics and the spatial distribution of exploited species can help to avoid unwanted catches: The case of the NW mediterranean fishing grounds
+23997,Gargan_etal,2011,Observational,Freshwater,Local,,europe,Ireland,"Comparison of field- and GIS-based assessments of barriers to Atlantic salmon migration: A case study in the Nore Catchment, Republic of Ireland"
+24000,Garrard_etal,2016,Observational,Terrestrial,Local,200,asia,Nepal,"Land Use and Land Cover Change in Sagarmatha National Park, a World Heritage Site in the Himalayas of Eastern Nepal"
+24001,Garratt_etal,2019,Observational,Terrestrial,Local,6,north atlantic,United Kingdom,Mapping the consequences of artificial light at night for intertidal ecosystems
+24003,Garrote_etal,2018,Observational,Terrestrial,Sub-national,,europe,Spain,Prediction of iberian lynx road–mortality in southern Spain: A new approach using the MaxEnt algorithm
+24013,Genovart_etal,2017,Observational,Marine,Multi-national,0.1,mediterranean,Spain,Differential adult survival at close seabird colonies: The importance of spatial foraging segregation and bycatch risk during the breeding season
+24016,Gerlach,2002,Observational,Terrestrial,Local,,north america,United States,Alien plant species threat assessment and management prioritization for Sequoia-Kings Canyon and Yosemite National Parks
+24024,Ghorbani_etal,2014,Observational,Terrestrial,Sub-national,,asia,Iran,Wild orchid tuber collection in Iran: A wake-up call for conservation
+24025,Ghulam_etal,2015,Observational,Terrestrial,Local,30,africa,Madagascar,Remote Sensing Based Spatial Statistics to Document Tropical Rainforest Transition Pathways
+24029,Gibson_etal,2018,Observational,Terrestrial,Local,,north america,United States,Effects of power lines on habitat use and demography of greater sage-grouse (Centrocercus urophasianus)
+24030,Giersch_etal,2015,Observational,Terrestrial,Local,,north america,United States,Climate-induced range contraction of a rare alpine aquatic invertebrate
+24034,Gillen and Kiviat,2012,Observational,Terrestrial,Sub-national,,north america,United States,Environmental reviews and case studies: Hydraulic fracturing threats to species with restricted geographic ranges in the Eastern United States
+24036,Gilman_etal,2008,Experimental,Marine,Local,,north pacific,Hawaii,Reducing seabird bycatch in the Hawaii longline tuna fishery
+24038,Gimpel_etal,2013,Observational,Marine,Local,5,north atlantic,Germany,A spatially explicit risk approach to support marine spatial planning in the German EEZ
+24039,Giordano_etal,2008,Observational,Terrestrial,Local,,south america,Argentina,Abundance and spatial distribution of Greater Rhea Rhea americana in two sites on the pampas grasslands with different land use
+24042,Girardet_etal,2015,Observational,Terrestrial,Sub-national,10,europe,France,Does regional landscape connectivity influence the location of roe deer roadkill hotspots?
+24050,Goldberg_etal,2020,Observational,Marine,Global,30,Unknown,Unknown,Global declines in human-driven mangrove loss
+24053,Gomez_etal,2014,Observational,Freshwater,Local,0.05,south america,Argentina,Habitat suitability and anthropogenic correlates of Neotropical river otter (Lontra longicaudis) distribution
+24055,Gomez_etal,2017,Observational,Marine,Sub-national,1,north atlantic,Canada,Predicted distribution of whales at risk: Identifying priority areas to enhance cetacean monitoring in the Northwest Atlantic Ocean
+24060,González-Andrés_etal,2020,Observational,Marine,Local,0.03,north pacific,Costa Rica,Illegal fishing in Isla del Coco National Park: Spatial-temporal distribution and the economic trade-offs
+24062,Gonzalez-Quevedo_etal,2014,Observational,Terrestrial,Sub-national,,europe,Spain,Predictors of malaria infection in a wild bird population: Landscape-level analyses reveal climatic and anthropogenic factors
+24064,Gonzalez-Suarez_etal,2013,Observational,Marine,Global,2,Unknown,Unknown,Which intrinsic traits predict vulnerability to extinction depends on the actual threatening processes
+24065,González-Suárez_etal,2018,Observational,Terrestrial,National,1,south america,Brazil,Spatial and species-level predictions of road mortality risk using trait data
+24067,Good_etal,2020,Observational,Marine,Sub-national,4.8,north pacific,United States,Plastics in the Pacific: Assessing risk from ocean debris for marine birds in the California Current Large Marine Ecosystem
+24078,Graham_etal,2016,Observational,Terrestrial,Global,1,Unknown,Unknown,A Global-Scale Evaluation of Primate Exposure and Vulnerability to Climate Change
+24079,Grainger_etal,2018,Observational,Terrestrial,Multi-national,1,asia,Myanmar,Conservation status of Phasianidae in Southeast Asia
+24086,Grecchi_etal,2014,Observational,Freshwater,Sub-national,,south america,Brazil,Land use and land cover changes in the Brazilian Cerrado: A multidisciplinary approach to assess the impacts of agricultural expansion
+24088,Grech and Marsh,2008,Observational,Marine,Sub-national,,south pacific,Australia,Rapid assessment of risks to a mobile marine mammal in an ecosystem-scale marine protected area
+24087,Grech_etal,2008,Observational,Marine,Sub-national,,south pacific,Australia,A spatial assessment of the risk to a mobile marine mammal from bycatch
+24094,Grenouillet and Comte,2014,Observational,Freshwater,National,64,europe,France,Illuminating geographical patterns in species' range shifts
+24096,Grigolato_etal,2018,Observational,Terrestrial,Local,,europe,Italy,Assessment of noise level and noise propagation generated by light-lift helicopters in mountain natural environments
+24101,Guerra_etal,2017,Observational,Terrestrial,Local,,south america,Brazil,Urban or rural areas: which types of surrounding land use induce stronger edge effects on the functional traits of tropical forests plants?
+24104,Guerrini_etal,2019,Observational,Marine,Sub-national,,europe,Italy,Modeling Plastics Exposure for the Marine Biota: Risk Maps for Fin Whales in the Pelagos Sanctuary (North-Western Mediterranean)
+24107,Gül and Griffen,2018,Observational,Marine,Local,,north america,United States,Impacts of human disturbance on ghost crab burrow morphology and distribution on sandy shores
+24108,Gumbs_etal,2020,Observational,Terrestrial,Global,1,Unknown,Unknown,Global priorities for conservation of reptilian phylogenetic diversity in the face of human impacts
+24110,Gunson_etal,2012,Observational,Terrestrial,Local,15,north america,Canada,"A tool to prioritize high-risk road mortality locations for wetland-forest herpetofauna in southern Ontario, Canada"
+24113,Guo_etal,2018,Observational,Terrestrial,Global,0.5,Unknown,Unknown,Land-use change interacts with climate to determine elevational species redistribution
+24112,Guo_etal,2005,Observational,Terrestrial,Sub-national,1,north america,United States,Support vector machines for predicting distribution of Sudden Oak Death in California
+24114,Gutiérrez_etal,2020,Observational,Terrestrial,Local,1,europe,Spain,Impact model of urban development on steppic birds in natura 2000 spaces
+24120,Hager_etal,2013,Observational,Terrestrial,Local,,north america,United States,Window Area and Development Drive Spatial Variation in Bird-Window Collisions in an Urban Landscape
+24122,Haines_etal,2010,Observational,Terrestrial,Sub-national,90,north america,United States,Using a Distribution and Conservation Status Weighted Hotspot Approach to Identify Areas in Need of Conservation Action to Benefit Idaho Bird Species
+24123,Hajiahmadi and Amanollahi,2018,Observational,Terrestrial,Local,,asia,Indonesia,Fuzzy risk assessment modelling of wild animal life in Bijar protected area
+24125,Halpern_etal,2008,Observational,Marine,Global,,Unknown,Unknown,A global map of human impact on marine ecosystems
+24126,Halpern_etal,2009,Observational,Marine,Global,,Unknown,Unknown,Global priority areas for incorporating land-sea connections in marine conservation
+24128,Halpern_etal,2015,Observational,Marine,Global,1,Unknown,Unknown,Spatial and temporal changes in cumulative human impacts on the world's ocean
+24127,Halpern_etal,2009,Observational,Marine,Sub-national,1,north pacific,United States,Mapping cumulative human impacts to California Current marine ecosystems
+24129,Hamilton_etal,2016,Observational,Marine,Local,,south pacific,Solomon Islands,Hyperstability masks declines in bumphead parrotfish (Bolbometopon muricatum) populations
+24133,Hammouda_etal,2019,Observational,Terrestrial,Local,,africa,Algeria,Impact of agrarian practices and some pastoral uses on vegetation in Algerian steppe rangelands
+24138,Han_etal,2019,Observational,Freshwater,Sub-national,16,asia,China,"The effect of the grain for green program on ecosystem health in the upper reaches of the Yangtze river basin: A case study of eastern Sichuan, China"
+24139,Han_etal,2019,Observational,Terrestrial,Sub-national,km2,asia,China,Integrated modeling to identify priority areas for the conservation of the endangered plant species in headwater areas of Asia
+24140,Handley_etal,2020,Observational,Marine,Sub-national,,southern ocean,South Georgia and the South Sandwich Islands,Evaluating the effectiveness of a large multi-use MPA in protecting Key Biodiversity Areas for marine predators
+24145,Hao_etal,2018,Observational,Terrestrial,Sub-national,1,asia,China,Quantifying the effects of overgrazing on mountainous watershed vegetation dynamics under a changing climate
+24149,Hari_etal,2014,Observational,Terrestrial,Sub-national,500,asia,India,"Landscape level analysis of disturbance regimes in protected areas of Rajasthan, India"
+24150,Harik_etal,2017,Observational,Terrestrial,Local,15,africa,France,Implications of adopting a biodiversity-based vulnerability index versus a shoreline environmental sensitivity index on management and policy planning along coastal areas
+24153,Harris_etal,2014,Observational,Terrestrial,Local,30,asia,Indonesia,Rapid deforestation threatens mid-elevational endemic birds but climate change is most important at higher elevations
+24154,Harris_etal,2017,Observational,Marine,Multi-national,5,indian ocean,South Africa,Managing conflicts between economic activities and threatened migratory marine species toward creating a multiobjective blue economy
+24155,Harrison_etal,2011,Observational,Terrestrial,Sub-national,,asia,Indonesia,Hunting of flying foxes and perception of disease risk in Indonesian Borneo
+24156,Harsch and Hillerislambers,2016,Observational,Terrestrial,Sub-national,,north america,Canada,Climate warming and seasonal precipitation change interact to limit species distribution shifts across Western North America
+24158,Hart_etal,2014,Observational,Marine,Sub-national,100,north atlantic,United States,"Migration, foraging, and residency patterns for northern gulf loggerheads: Implications of local threats and international movements"
+24159,Hart_etal,2018,Observational,Marine,Sub-national,100,north atlantic,United States,Marine threats overlap key foraging habitat for two imperiled sea turtle species in the Gulf of Mexico
+24160,Hassan_etal,2018,Observational,Terrestrial,Local,10,asia,Bangladesh,"Rohingya refugee crisis and forest cover change in Teknaf, Bangladesh"
+24162,Hauser_etal,2018,Observational,Marine,Multi-national,,arctic ocean,Canada,Vulnerability of arctic marine mammals to vessel traffic in the increasingly ice-free northwest passage and Northern Sea Route
+24163,Hausmann_etal,2019,Observational,Terrestrial,Global,1,Unknown,Unknown,Assessing global popularity and threats to Important Bird and Biodiversity Areas using social media data
+24167,Hayashi_etal,2018,Observational,Terrestrial,Sub-national,5,south america,Brazil,The effect of anthropogenic drivers on spatial patterns of mangrove land use on the Amazon coast
+24169,Hayes_etal,2015,Observational,Terrestrial,Multi-national,1,north america,Canada,Seasonally-Dynamic Presence-Only Species Distribution Models for a Cryptic Migratory Bat Impacted by Wind Energy Development
+24170,Haywood_etal,2016,Observational,Marine,Local,,south pacific,Papua New Guinea,"Mine waste disposal leads to lower coral cover, reduced species richness and a predominance of simple coral growth forms on a fringing coral reef in Papua New Guinea"
+24174,He_etal,2018,Observational,Freshwater,Global,10,Unknown,Unknown,"Freshwater megafauna diversity: Patterns, status and threats"
+24175,Heard_etal,2015,Observational,Freshwater,Local,,australasia,Australia,Refugia and connectivity sustain amphibian metapopulations afflicted by disease
+24177,Hedd_etal,2016,Observational,Marine,Sub-national,10000,arctic ocean,Canada,"Characterization of seabird bycatch in eastern Canadian waters, 1998–2011, assessed from onboard fisheries observer data"
+24180,Hegland and Hamre,2018,Observational,Terrestrial,Sub-national,,europe,Norway,Scale-dependent effects of landscape composition and configuration on deer-vehicle collisions and their relevance to mitigation and planning options
+24184,Hein_etal,2015,Observational,Marine,Local,,south china sea,Thailand,Assessing baseline levels of coral health in a newly established marine protected area in a global scuba diving hotspot
+24186,Heinemeyer_etal,2019,Observational,Terrestrial,Sub-national,,north america,United States,Wolverines in winter: indirect habitat loss and functional responses to backcountry recreation
+24188,Heinrich_etal,2019,Observational,Marine,Local,,south pacific,Chile,Fine-scale habitat partitioning of Chilean and Peale's dolphins and their overlap with aquaculture
+24192,Helldin,2019,Observational,Terrestrial,National,,europe,Sweden,Predicted impacts of transport infrastructure and traffic on bird conservation in Swedish Special Protection Areas
+24194,Hemami_etal,2018,Observational,Marine,Local,4,indian ocean,Iran,"Population estimate and distribution pattern of Indian Ocean humpback dolphin (Sousa plumbea) in an industrialised bay, northwestern Persian Gulf"
+24195,Henriques_etal,2014,Observational,Marine,National,1,north atlantic,Portugal,Structural and functional trends indicate fishing pressure on marine fish assemblages
+24197,Herder_etal,2012,Observational,Freshwater,Local,,asia,Indonesia,"Alien invasion in Wallace's Dreamponds: Records of the hybridogenic ""flowerhorn"" cichlid in lake Matano, with an annotated checklist of fish species introduced to the Malili Lakes system in Sulawesi"
+24199,Hermoso_etal,2015,Observational,Freshwater,Sub-national,,australasia,Australia,Catchment zoning for freshwater conservation: Refining plans to enhance action on the ground
+24202,Hernández-Lambraño_etal,2018,Observational,Terrestrial,Sub-national,20,europe,Spain,Where to start? Development of a spatial tool to prioritise retrofitting of power line poles that are dangerous to raptors
+24203,Hernández-Matías_etal,2020,Observational,Terrestrial,Sub-national,100,europe,Spain,Using multi-scale spatial prioritization criteria to optimize non-natural mortality mitigation of target species
+24205,Hernout_etal,2018,Observational,Terrestrial,National,100,europe,United Kingdom,Interspecific variation in the spatially-explicit risks of trace metals to songbirds
+24206,Herr_etal,2009,Observational,Marine,Sub-national,36,north atlantic,Germany,Spatio-temporal associations between harbour porpoise Phocoena phocoena and specific fisheries in the German Bight
+24208,Hervé_etal,2016,Observational,Freshwater,Sub-national,100,europe,France,On the importance of taking into account agricultural practices when defining conservation priorities for regional planning
+24211,Hiddink_etal,2015,Observational,Marine,Multi-national,0.2,north atlantic,United Kingdom,Temperature tracking by North Sea benthic invertebrates in response to climate change
+24212,Hierink_etal,2020,Observational,Terrestrial,Global,,Unknown,Unknown,Forty-four years of global trade in CITES-listed snakes: Trends and implications for conservation and public health
+24215,Hillers_etal,2008,Observational,Terrestrial,Local,m,africa,Guinea,"Assessment of the distribution and conservation status of the viviparous toad Nimbaphrynoides occidentalis on Monts Nimba, Guinea"
+24222,Hogan_etal,2012,Observational,Freshwater,Sub-national,30,north america,United States,Estimating the cumulative ecological effect of local scale landscape changes in South Florida
+W26586,Hogg_etal,2010,Observational,Marine,Sub-national,,arctic ocean,Canada,Deep-sea sponge grounds: Reservoirs of Biodiversity
+24227,Holon_etal,2015,Observational,Marine,Sub-national,20,mediterranean,France,Fine-scale cartography of human impacts along French Mediterranean coasts: A relevant map for the management of marine ecosystems
+24228,Holon_etal,2015,Observational,Marine,Local,25,mediterranean,France,The impact of 85 years of coastal development on shallow seagrass beds (Posidonia oceanica L. (Delile)) in South Eastern France: A slow but steady loss without recovery
+24229,Holon_etal,2018,Observational,Marine,Multi-national,50,mediterranean,France,A predictive model based on multiple coastal anthropogenic pressures explains the degradation status of a marine ecosystem: Implications for management and conservation
+24232,Hornseth_etal,2018,Observational,Terrestrial,Sub-national,1,north america,United States,Motorized Activity on Legacy Seismic Lines: A Predictive Modeling Approach to Prioritize Restoration Efforts
+24242,Howard_etal,2018,Observational,Freshwater,Sub-national,,north america,United States,A freshwater conservation blueprint for California: Prioritizing watersheds for freshwater biodiversity
+24247,Hu_etal,2018,Observational,Marine,Sub-national,30,north atlantic,United States,Association between nighttime artificial light pollution and sea turtle nest density along Florida coast: A geospatial study using VIIRS remote sensing data
+24253,Hughes,2019,Observational,Terrestrial,Global,,Unknown,Unknown,Understanding and minimizing environmental impacts of the Belt and Road Initiative
+24256,Hui_etal,2020,Observational,Terrestrial,Local,,asia,China,"Vascular plants in the tourist area of Lushan national nature reserve, China: Status, threats and conservation"
+24257,Hull_etal,2011,Observational,Terrestrial,Local,,asia,China,Evaluating the efficacy of zoning designations for protected area management
+24258,Hull_etal,2014,Observational,Terrestrial,Local,m,asia,China,Impact of livestock on giant pandas and their habitat
+W26592,Humber_etal,2014,S_Review,Marine,Global,,Unknown,Unknown,So excellent a fishe: a global overview of legal marine turtle fisheries
+24262,Hurley_etal,2019,Observational,Marine,Sub-national,25,north atlantic,Canada,Spatiotemporal bycatch analysis of the Atlantic halibut ( Hippoglossus hippoglossus ) longline fishery survey indicates hotspots for species of conservation concern
+24265,Hyde_etal,2018,Observational,Terrestrial,Sub-national,30,south america,Brazil,Transmission lines are an under-acknowledged conservation threat to the Brazilian Amazon
+24266,Iacona_etal,2014,Observational,Terrestrial,Sub-national,30,south america,Brazil,Predicting the invadedness of protected areas
+24267,Iacona_etal,2016,Observational,Terrestrial,Sub-national,,north america,United States,Predicting the presence and cover of management relevant invasive plant species on protected areas
+24268,Ibanez_etal,2019,Observational,Terrestrial,National,,australasia,New Caledonia,"Twenty years after Jaffré et al. (1998), is the system of protected areas now adequate in New Caledonia?"
+24269,Ibharim_etal,2015,Observational,Terrestrial,Local,,asia,Malaysia,Mapping mangrove changes in the Matang Mangrove Forest using multi temporal satellite imageries
+24270,Ibouroi_etal,2019,Observational,Terrestrial,Local,,africa,Comoros,The first comprehensive survey of habitat suitability and population size for the endangered Grande Comoro Scops Owl (Otus pauliani): implications for its conservation
+24274,Iglesias-Merchan_etal,2015,Observational,Terrestrial,Local,100,europe,Spain,Transportation planning and quiet natural areas preservation: Aircraft overflights noise assessment in a National Park
+24288,Ioki_etal,2019,Observational,Terrestrial,Local,,asia,Malaysia,"Supporting forest conservation through community-based land use planning and participatory GIS – lessons from Crocker Range Park, Malaysian Borneo"
+24290,Issaris_etal,2012,Observational,Marine,Sub-national,,mediterranean,Greece,Ecological mapping and data quality assessment for the needs of ecosystem-based marine spatial management: Case study Greek Ionian Sea and the adjacent gulfs
+24291,Isunju and Kemp,2016,Observational,Freshwater,Local,,africa,Uganda,"Spatiotemporal analysis of encroachment on wetlands: A case of Nakivubo wetland in Kampala, Uganda"
+24295,Jackson_etal,2020,Observational,Terrestrial,Global,1,Unknown,Unknown,Understanding the co?occurrence of tree loss and modern slavery to improve efficacy of conservation actions and policies
+25557,Jacoby_etal,2020,Observational,Marine,Local,0.01,indian ocean,Chagos Archipelago,"Shark movement strategies influence poaching risk and can guide enforcement decisions in a large, remote marine protected area"
+24297,Jalali_etal,2015,Observational,Marine,Local,,indian ocean,Australia,Exploring spatiotemporal trends in commercial fishing effort of an abalone fishing zone: A GIS-based hotspot model
+24299,Janik_etal,2020,Observational,Terrestrial,Local,0.25,europe,Czech Republic,Landscape monitoring: Urbanization and recreation in protected areas. Where to draw the line?
+24302,Jaric_etal,2019,Observational,Freshwater,Continental,,europe,Unknown,Susceptibility of European freshwater fish to climate change: Species profiling based on life-history and environmental characteristics
+24304,Jarvis_etal,2010,Observational,Terrestrial,Continental,1,south america,Unknown,Assessment of threats to ecosystems in South America
+24307,Jenkins_etal,2016,Observational,Marine,Global,2500,Unknown,Unknown,Global and regional priorities for marine biodiversity protection
+24310,Jensen_etal,2019,Observational,Terrestrial,Global,,Unknown,Unknown,Exploring the international trade in African snakes not listed on CITES: highlighting the role of the internet and social media
+24313,Jézéquel_etal,2020,Observational,Freshwater,Multi-national,,south america,Brazil,Freshwater fish diversity hotspots for conservation priorities in the Amazon Basin
+24314,"Jia,S.",2016,Observational,Terrestrial,Sub-national,1,north america,United States,Understanding the Ecological Challenges in California Protected Areas Through the Lens of Remote Sensing Technologies
+24315,Jiang_etal,2020,Observational,Terrestrial,Continental,30,africa,Unknown,Assessing the impact of climate change on the spatio-temporal distribution of foot-and-mouth disease risk for elephants
+24328,Jones Alice_etal,2018,Observational,Marine,Sub-national,250,indian ocean,Australia,Capturing expert uncertainty in spatial cumulative impact assessments
+24322,Jones and Power,2012,Observational,Terrestrial,Sub-national,5,europe,United Kingdom,Field-scale evaluation of effects of nitrogen deposition on the functioning of heathland ecosystems
+24321,Jones_etal,2009,Observational,Freshwater,National,,africa,Madagascar,The perfect invader: A parthenogenic crayfish poses a new threat to Madagascar's freshwater biodiversity
+24326,Jones_etal,2017,Observational,Marine,National,25,north atlantic,United Kingdom,Seals and shipping: quantifying population risk and individual exposure to vessel noise
+24329,Jongsomjit_etal,2013,Observational,Terrestrial,Sub-national,800,north america,United States,Between a rock and a hard place: the impacts of climate change and housing development on breeding birds in California
+24341,Kahler_etal,2012,Observational,Terrestrial,Local,10,africa,Namibia,Poaching Risks in Community-Based Natural Resource Management
+24345,Kamino_etal,2020,Observational,Freshwater,Sub-national,,south america,Brazil,"Conservation paradox: Large-scale mining waste in protected areas in two global hotspots, southeastern Brazil"
+24346,Kamp_etal,2015,Observational,Terrestrial,Continental,degrees,asia,Unknown,Global population collapse in a superabundant migratory bird and illegal trapping in China
+24347,Kamrowski_etal,2014,Observational,Marine,National,,indian ocean,Australia,Temporal changes in artificial light exposure of marine turtle nesting areas
+24352,Kano_etal,2016,Observational,Freshwater,Multi-national,km2,asia,Cambodia,Impacts of dams and global warming on fish biodiversity in the Indo-Burma hotspot
+24353,Kantola_etal,2019,Observational,Terrestrial,Sub-national,30,north america,United States,Spatial risk assessment of eastern monarch butterfly road mortality during autumn migration within the southern corridor
+24358,Karimi and Jones,2020,Observational,Terrestrial,National,100,asia,Iran,Assessing national human footprint and implications for biodiversity conservation in Iran
+24364,Katsis_etal,2018,Observational,Terrestrial,Local,,africa,Kenya,"Spatial Patterns of Primate Electrocutions in Diani, Kenya"
+24365,Katzner_etal,2020,Observational,Terrestrial,Sub-national,,north america,United States,Assessing population-level consequences of anthropogenic stressors for terrestrial wildlife
+24366,Kauano É_etal,2017,Observational,Freshwater,Sub-national,,south america,Brazil,Illegal use of natural resources in federal protected areas of the Brazilian Amazon
+24368,Kehoe_etal,2015,Observational,Terrestrial,Global,12100,Unknown,Unknown,Global patterns of agricultural land-use intensity and vertebrate diversity
+24372,Keith_etal,2012,Observational,Terrestrial,Local,25,australasia,Australia,"Spatial Analysis of Risks Posed by Root Rot Pathogen, Phytophthora cinnamomi: Implications for Disease Management"
+24375,Kelly and Meentemeyer,2002,Observational,Terrestrial,Sub-national,5,north america,United States,Landscape dynamics of the spread of Sudden Oak Death
+24381,Khaliq_etal,2014,Observational,Terrestrial,Global,,Unknown,Unknown,Global variation in thermal tolerances and vulnerability of endotherms to climate change
+24389,Kidane_etal,2012,Observational,Terrestrial,Local,2.5,africa,Ethiopia,"Vegetation dynamics, and land use and land cover change in the Bale Mountains, Ethiopia"
+24391,Kilshaw_etal,2016,Observational,Terrestrial,Sub-national,500,europe,United Kingdom,Mapping the spatial configuration of hybridization risk for an endangered population of the European wildcat (Felis silvestris silvestris) in Scotland
+24392,Kim_etal,2020,Observational,Marine,National,0.5,north pacific,South Korea,Risk-based fisheries assessment considering spatio-temporal component for Korean waters
+24395,Kirk_etal,2019,Observational,Terrestrial,Local,,africa,Tunisia,Grazing effects on woody and herbaceous plant biodiversity on a limestone mountain in northern Tunisia
+24396,Kirkman_etal,2019,Observational,Marine,Multi-national,km2,south atlantic,Angola,Using Systematic Conservation Planning to support Marine Spatial Planning and achieve marine protection targets in the transboundary Benguela Ecosystem
+24397,Kirol_etal,2015,Observational,Terrestrial,Local,30,north america,United States,Identifying Greater Sage-Grouse source and sink habitats for conservation planning in an energy development landscape
+24400,Kitzes and Shirley,2016,Observational,Freshwater,Sub-national,,asia,Malaysia,Estimating biodiversity impacts without field surveys: A case study in northern Borneo
+24401,Kitzes_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown,Consumption-Based Conservation Targeting: Linking Biodiversity Loss to Upstream Demand through a Global Wildlife Footprint
+24404,Klarenberg_etal,2019,Observational,Freshwater,Sub-national,,south america,Brazil,A spatiotemporal natural-human database to evaluate road development impacts in an Amazon trinational frontier
+24411,Knouft and Chu,2015,Observational,Freshwater,Local,30,north america,United States,Using watershed-scale hydrological models to predict the impacts of increasing urbanization on freshwater fish assemblages
+24415,Koen_etal,2018,Observational,Freshwater,Global,400,Unknown,Unknown,Emerging threat of the 21st century lightscape to global biodiversity
+24416,Koerner_etal,2017,Observational,Terrestrial,Multi-national,,africa,Gabon,Vertebrate community composition and diversity declines along a defaunation gradient radiating from rural villages in Gabon
+24417,Kokkonen_etal,2010,Observational,Marine,Local,1,arctic ocean,Finland,Dynamic mapping of nature values to support prioritization of coastal oil combating
+24418,Kolbe_etal,2016,Observational,Terrestrial,Sub-national,,north america,United States,Effects of natural and anthropogenic environmental influences on tree community composition and structure in forests along an urban-wildland gradient in southwestern Ohio
+24420,Kominoski_etal,2018,Observational,Freshwater,Sub-national,,north america,United States,Patterns and drivers of fish extirpations in rivers of the American Southwest and Southeast
+24421,Konstantopoulos_etal,2020,Observational,Terrestrial,National,100,europe,Cyprus,"A spatially explicit impact assessment of road characteristics, road-induced fragmentation and noise on birds species in Cyprus"
+24422,Kooistra_etal,2005,Observational,Terrestrial,Local,,europe,Netherlands,Spatial variability and uncertainty ecological risk assessment: A case study on the potential risk of cadmium for the little owl in a Dutch river flood plain
+24423,Kope?_etal,2020,Observational,Terrestrial,Local,1,europe,Poland,Application of airborne hyperspectral data for mapping of invasive alien Spiraea tomentosa L.: a serious threat to peat bog plant communities
+24426,Korpilo_etal,2018,Observational,Freshwater,Local,,europe,Finland,"Where are the hotspots and coldspots of landscape values, visitor use and biodiversity in an urban forest?"
+24428,Kostoski_etal,2010,Observational,Freshwater,Local,,europe,Albania,A freshwater biodiversity hotspot under pressure - Assessing threats and identifying conservation needs for ancient Lake Ohrid
+24431,Kovach_etal,2017,Observational,Freshwater,Local,,north america,Canada,"Climate, invasive species and land use drive population dynamics of a cold-water specialist"
+24436,Kraus_etal,2012,Observational,Terrestrial,Sub-national,,north america,United States,"Diet and conservation implications of an invasive chameleon, Chamaeleo jacksonii (Squamata: Chamaeleonidae) in Hawaii"
+24437,Krawczyk_etal,2019,Observational,Terrestrial,Local,,europe,Greece,Effects of touristic development on Mediterranean island wildlife
+24443,Kuemmerle_etal,2014,Observational,Terrestrial,Sub-national,10,asia,Russia,Potential impacts of oil and gas development and climate change on migratory reindeer calving grounds across the Russian Arctic
+24446,Kumagai_etal,2018,Observational,Marine,Sub-national,1,north pacific,Japan,High-resolution modeling of thermal thresholds and environmental influences on coral bleaching for local and regional reef management
+24450,Kurekin_etal,2019,Observational,Marine,National,20,north atlantic,Ghana,Operational monitoring of illegal fishing in Ghana through exploitation of satellite earth observation and AIS data
+24451,Kurland_etal,2018,Observational,Terrestrial,Local,1,north america,United States,The spatial pattern of redwood burl poaching and implications for prevention
+24455,Kwak_etal,2019,Observational,Freshwater,Local,,north america,United States,Ecology and conservation of the American eel in the Caribbean region
+24460,Lagabrielle_etal,2009,Observational,Terrestrial,Local,25,africa,Reunion,Identifying and mapping biodiversity processes for conservation planning in islands: A case study in Réunion Island (Western Indian Ocean)
+24461,Lagabrielle_etal,2018,Observational,Marine,Sub-national,10,indian ocean,South Africa,Multi-scale multi-level marine spatial planning: A novel methodological approach applied in south africa
+24465,Laneri_etal,2010,Observational,Marine,Multi-national,,mediterranean,Morocco,Trawling regime influences longline seabird bycatch in the Mediterranean: New insights from a small-scale fishery
+24471,Lasky_etal,2011,Observational,Terrestrial,Multi-national,,north america,United States,Conservation biogeography of the US-Mexico border: A transcontinental risk assessment of barriers to animal dispersal
+24472,Laslo,2017,Observational,Freshwater,Local,,europe,Romania,Mapping and assessment of ecosystem services from divici-pojejena wetland based on recommended methodology
+24473,Lasram_etal,2016,Observational,Marine,National,0.1,mediterranean,Tunisia,Cumulative human threats on ish biodiversity components in Tunisian waters
+24474,Latrubesse_etal,2020,Observational,Freshwater,Multi-national,,south america,Bolivia,Vulnerability of the biota in riverine and seasonally flooded habitats to damming of Amazonian rivers
+24475,Lattuada_etal,2020,Observational,Marine,Multi-national,,caspian sea,Russia,Endemic Caspian Sea mollusks in hotspot and non-hotspot areas differentially affected by anthropogenic pressures
+24481,Lavorel_etal,2020,Observational,Terrestrial,Local,10,europe,France,Interactions between outdoor recreation and iconic terrestrial vertebrates in two French alpine national parks
+24483,Lawler_etal,2003,Observational,Terrestrial,Sub-national,1,north america,United States,Integrating representation and vulnerability: Two approaches for prioritizing areas for conservation
+W26587,Leach_etal,2016,Observational,Terrestrial,Continental,10000,africa,Unknown,Potential threat to areas of biodiversity importance from current and emerging oil and gas activities in Africa
+24500,Leclerc_etal,2018,Observational,Freshwater,Global,,Unknown,Unknown,Insular threat associations within taxa worldwide
+24502,Lee and Jetz,2008,Observational,Terrestrial,Global,0.5,Unknown,Unknown,Future battlegrounds for conservation under global change
+24503,Lee_etal,2016,Observational,Marine,Sub-national,1,north pacific,United States,"Stranding Mortality Patterns in California Sea Lions and Steller Sea Lions in Oregon and Southern Washington, 2006 to 2014"
+24507,Leeney_etal,2008,Observational,Marine,Sub-national,400,north atlantic,United Kingdom,Spatio-temporal analysis of cetacean strandings and bycatch in a UK fisheries hotspot
+24511,Lehnert_etal,2014,Observational,Terrestrial,Sub-national,,europe,Germany,Wind farm facilities in Germany kill noctule bats from near and far
+24516,Leprieur_etal,2008,Observational,Freshwater,Global,0.5,Unknown,Unknown,Fish invasions in the world's river systems: When natural processes are blurred by human activities
+24518,Lessmann_etal,2019,Observational,Freshwater,Sub-national,0.25,south america,Ecuador,Validating anthropogenic threat maps as a tool for assessing river ecological integrity in Andean-Amazon basins
+24525,Lewis_etal,2020,Observational,Terrestrial,Global,,Unknown,Unknown,A Global Perspective on Firefly Extinction Threats
+24536,Li_etal,2016,Observational,Terrestrial,Global,10,Unknown,Unknown,Risk of biological invasions is concentrated in biodiversity hotspots
+24527,Li_etal,2011,Observational,Terrestrial,Sub-national,1,australasia,Australia,Deriving spatio-temporal profiles of global forest fragmentation and disturbance patterns from the latest globcover datasets
+24531,Li_etal,2011,Observational,Terrestrial,Local,,asia,China,Characterizing fragmentation of the collective forests in southern China from multitemporal Landsat imagery: A case study from Kecheng district of Zhejiang province
+24540,Li_etal,2017,Observational,Terrestrial,Local,,north america,United States,From endogenous to exogenous pattern formation: Invasive plant species changes the spatial distribution of a native ant
+24544,Li_etal,2018,Observational,Terrestrial,Sub-national,1,asia,China,Human footprint in Tibet: Assessing the spatial layout and effectiveness of nature reserves
+24545,Li_etal,2018,Observational,Terrestrial,Sub-national,,asia,China,Mapping human influence intensity in the Tibetan Plateau for conservation of ecological service functions
+24548,Li_etal,2019,Observational,Terrestrial,Local,,asia,China,"Effects of long-term coastal reclamation on suitable habitat and wintering population size of the endangered Red-crowned Crane, Grus japonensis"
+24551,Li_etal,2019,Observational,Terrestrial,Sub-national,,asia,China,"Assessing Changes of Habitat Quality for Shorebirds in Stopover Sites: a Case Study in Yellow River Delta, China"
+26547,Li_etal,2010,Observational,Freshwater,Local,100,asia,China,Wetland mitigation and its ecological conserquences
+24553,Licata_etal,2019,Observational,Terrestrial,Local,,africa,Madagascar,"Abundance, distribution and spread of the invasive Asian toad Duttaphrynus melanostictus in eastern Madagascar"
+24556,Liermann_etal,2012,Observational,Freshwater,Global,,Unknown,Unknown,Implications of Dam Obstruction for Global Freshwater Fish Diversity
+24557,Lieske_etal,2014,Observational,Marine,Sub-national,1,north atlantic,Canada,"Maps, models, and marine vulnerability: Assessing the community distribution of seabirds at-sea"
+24558,Lieske_etal,2020,Observational,Marine,Sub-national,400,north atlantic,Canada,“Seas of risk”: Assessing the threats to colonial-nesting seabirds in Eastern Canada
+24565,Lin_etal,2008,Observational,Terrestrial,Local,,asia,China,"Assessing egret ecological safety in the urban environment: A case study in Xiamen, China"
+24566,Lin_etal,2019,Observational,Terrestrial,National,km,asia,Taiwan,Spatiotemporal identification of roadkill probability and systematic conservation planning
+24567,Lin_etal,2020,Observational,Terrestrial,Local,,asia,Taiwan,Bird Species Richness in Relation to Land-Use Patch Structure and Vegetation Structure in a Forest-Agriculture Mosaic
+24574,Lindsey_etal,2016,Observational,Terrestrial,Continental,,africa,Angola,"The performance of African protected areas for lions and their prey, determinants of success and key conservation threats"
+24573,Lindsey_etal,2011,Observational,Terrestrial,Local,1,africa,Zimbabwe,Ecological and financial impacts of illegal bushmeat trade in Zimbabwe
+24576,Linke_etal,2013,Observational,Terrestrial,Local,,north america,Canada,Relationships between grizzly bears and human disturbances in a rapidly changing multi-use forest landscape
+24579,Lipp-Nissinen_etal,2018,Observational,Terrestrial,Local,,south america,Brazil,"Temporal dynamics of land use and cover in Paurá Lagoon region, Middle Coast of Rio Grande do Sul (RS), Brazil"
+24582,Liu_etal,2008,Observational,Terrestrial,Sub-national,,asia,China,Evaluating the influence of road networks on landscape and regional ecological risk-A case study in Lancang River Valley of Southwest China
+24585,Liu_etal,2012,Observational,Terrestrial,Local,,north america,United States,Almond organophosphate and pyrethroid use in the San Joaquin Valley and their associated environmental risk
+24590,Liu_etal,2018,Observational,Terrestrial,Local,,asia,China,Effects of Land Use Change on Ecosystem Services in Arid Area Ecological Migration
+24595,Liu_etal,2020,Observational,Freshwater,Sub-national,,asia,China,Conversion between natural wetlands and farmland in the Tumen river basin: A multiscale geospatial analysis
+24597,Livingston_etal,2017,Observational,Terrestrial,Sub-national,,north america,United States,Using changes in basal area increments to map relative risk of HWA impacts on hemlock growth across the Northeastern U.S.A
+24600,Loerzel_etal,2017,Observational,Marine,Local,1,north atlantic,United States Virgin Islands,SCUBA divers above the waterline: Using participatory mapping of coral reef conditions to inform reef management
+24601,Löfvenhaft_etal,2004,Observational,Terrestrial,Local,,europe,Sweden,Biotope patterns and amphibian distribution as assessment tools in urban landscape planning
+24605,Lohse_etal,2008,Observational,Freshwater,Local,,north america,United States,Forecasting relative impacts of land use on anadromous fish habitat to guide conservation planning
+24606,Loosen_etal,2019,Observational,Terrestrial,Sub-national,,north america,Canada,Land tenure shapes black bear density and abundance on a multi-use landscape
+24612,López-Sánchez_etal,2014,Observational,Terrestrial,Sub-national,,north america,United States,Effects of cattle management on oak regeneration in northern Californian Mediterranean oak woodlands
+24619,Loveridge_etal,2017,Observational,Terrestrial,Sub-national,500,africa,Zimbabwe,The landscape of anthropogenic mortality: how African lions respond to spatial variation in risk
+24620,Loveridge_etal,2020,Observational,Terrestrial,Sub-national,,africa,Zimbabwe,Evaluating the spatial intensity and demographic impacts of wire-snare bush-meat poaching on large carnivores
+24622,Lozano_etal,2017,Observational,Freshwater,Continental,,south america,Unknown,Native and non-native aquatic plants of South America: Comparing and integrating GBIF records with literature data
+24624,Lucifora_etal,2016,Observational,Freshwater,Multi-national,0.5,south america,Brazil,Geographic distribution of the short-tailed river stingray (Potamotrygon brachyura): Assessing habitat loss and fishing as threats to the world's largest obligate freshwater elasmobranch
+24627,Luizza_etal,2016,Observational,Freshwater,Sub-national,,north america,United States,Integrating subsistence practice and species distribution modeling: assessing invasive elodea’s potential impact on Native Alaskan subsistence of Chinook salmon and whitefish
+24628,Lunn and Moreau,2004,Observational,Marine,Sub-national,,south china sea,Indonesia,Unmonitored trade in marine ornamental fishes: The case of Indonesia's Banggai cardinalfish (Pterapogon kauderni)
+24633,Lyon_etal,2011,Observational,Terrestrial,Local,100,europe,Finland,"Biodiversity Hotspots and Visitor Flows in Oulanka National Park, Finland"
+24636,Macdonald_etal,2013,Observational,Terrestrial,Global,1,Unknown,Unknown,A problem shared is a problem reduced: Seeking efficiency in the conservation of felids and primates
+24642,Mach_etal,2017,Observational,Marine,Sub-national,,north pacific,United States,Assessment and management of cumulative impacts in California's network of marine protected areas
+24646,Maclean_etal,2014,Observational,Freshwater,Multi-national,4,africa,DRC,Papyrus swamp drainage and the conservation status of their avifauna
+24648,Macnearney_etal,2016,Observational,Terrestrial,Sub-national,,north america,Canada,Heading for the hills? Evaluating spatial distribution of woodland caribou in response to a growing anthropogenic disturbance footprint
+24654,Magioli_etal,2019,Observational,Terrestrial,Local,,south america,Brazil,Short and narrow roads cause substantial impacts on wildlife
+24655,Magliozzi_etal,2020,Observational,Freshwater,Continental,100,europe,Unknown,Assessing invasive alien species in European catchments: Distribution and impacts
+24656,Magness_etal,2011,Observational,Terrestrial,National,,north america,United States,A climate-change adaptation framework to reduce continental-scale vulnerability across conservation reserves
+24659,Magris_etal,2019,Observational,Freshwater,Sub-national,,south atlantic,Brazil,A modelling approach to assess the impact of land mining on marine biodiversity: Assessment in coastal catchments experiencing catastrophic events (SW Brazil)
+24660,Mahmood_etal,2019,Observational,Terrestrial,Sub-national,,asia,Pakistan,"Distribution and illegal killing of the Endangered Indian pangolin Manis crassicaudata on the Potohar Plateau, Pakistan"
+24661,Mahmoud_etal,2019,Observational,Terrestrial,Sub-national,60,africa,Cameroon,"Land-cover change threatens tropical forests and biodiversity in the Littoral Region, Cameroon"
+24663,Maiorano_etal,2019,Observational,Terrestrial,Sub-national,,europe,Italy,"Combining multi-state species distribution models, mortality estimates, and landscape connectivity to model potential species distribution for endangered species in human dominated landscapes"
+24667,Malavasi_etal,2016,Observational,Terrestrial,Sub-national,,europe,Italy,The impact of human pressure on landscape patterns and plant species richness in Mediterranean coastal dunes
+24673,Malherbe_etal,2019,Observational,Terrestrial,Local,,africa,South Africa,Mapping the loss of ecosystem services in a region under intensive land use along the Southern Coast of South Africa
+24674,Mali?-Limari_etal,2017,Observational,Terrestrial,National,50,europe,Croatia,Spatial analyses of landcover and relief diversity of the Medvednica Nature Park - Possible implications for optimising visitor pressure
+24676,Malik and Rai,2019,Observational,Freshwater,Sub-national,,asia,India,Drivers of land use/cover change and its impact on Pong Dam wetland
+24677,Malinowski,2019,Observational,Marine,Sub-national,,north atlantic,United States,High mercury concentrations in Atlantic Goliath Grouper: Spatial analysis of a vulnerable species
+24682,Manenti_etal,2014,Observational,Freshwater,Local,,europe,Italy,Austropotamobius pallipes reduction vs. Procambarus clarkii spreading: Management implications
+24692,Mao_etal,2018,Observational,Freshwater,National,,asia,China,Conversions between natural wetlands and farmland in China: A multiscale geospatial analysis
+24693,Marega-Imamura_etal,2020,S_Review,Marine,National,,south atlantic,Brazil,Scientific collaboration networks in research on human threats to cetaceans in Brazil
+24694,Marignani_etal,2017,Observational,Marine,Multi-national,1,mediterranean,France,Identification and prioritization of areas with high environmental risk in Mediterranean coastal areas: A flexible approach
+24695,Markham and Sangermano,2018,Observational,Freshwater,Local,,south america,Peru,"Evaluating Wildlife Vulnerability to Mercury Pollution From Artisanal and Small-Scale Gold Mining in Madre de Dios, Peru"
+24696,Marotta_etal,2011,Observational,Marine,Sub-national,,mediterranean,Italy,A decision-support system in ICZM for protecting the ecosystems: Integration with the habitat directive
+24698,Marques_etal,2019,Observational,Terrestrial,Local,100,europe,Spain,Wind turbines cause functional habitat loss for migratory soaring birds
+24699,Márquez_etal,2013,Observational,Terrestrial,Sub-national,,europe,Spain,Risk mapping of illegal poisoning of avian and mammalian predators
+24700,Martin_etal,2009,Observational,Marine,Sub-national,25,north atlantic,United Kingdom,The Channel habitat atlas for marine resource management (CHARM): An aid for planning and decision-making in an area under strong anthropogenic pressure
+24705,Martínez-Freiría and Brito,2012,Observational,Terrestrial,Local,100,europe,Spain,Quantification of road mortality for amphibians and reptiles in Hoces del Alto Ebro y Rudrón Natural Park in 2005
+24706,Martinez-Gutierrez and Ruiz-Saenz,2016,S_Review,Terrestrial,Global,,Unknown,Unknown,Diversity of susceptible hosts in canine distemper virus infection: A systematic review and data synthesis
+24710,Martins_etal,2013,Observational,Marine,Sub-national,,south atlantic,Brazil,Identifying priority areas for humpback whale conservation at Eastern Brazilian Coast
+24713,Martinuzzi_etal,2018,Observational,Terrestrial,Sub-national,1,south america,Argentina,Enhancing biodiversity conservation in existing land-use plans with widely available datasets and spatial analysis techniques
+24716,Marzolf_etal,2018,Observational,Freshwater,Local,,north america,United States,Inter- and intra-annual apple snail egg mass dynamics in a large southeastern US reservoir
+24717,Maseko_etal,2017,Observational,Terrestrial,Sub-national,,africa,South Africa,"Response of Crested Guinea-fowl (Guttera edouardi), a forest specialist, to spatial variation in land use in iSimangaliso Wetland Park, South Africa"
+24718,Masocha and Dube,2018,Observational,Terrestrial,Global,,Unknown,Unknown,Global terrestrial biomes at risk of cacti invasion identified for four species using consensual modelling
+24720,Mateo-Tomás_etal,2012,Observational,Terrestrial,Sub-national,1,europe,Spain,Alleviating human-wildlife conflicts: Identifying the causes and mapping the risk of illegal poisoning of wild fauna
+24723,"Mati Bancy, M.",2005,Observational,Terrestrial,Multi-national,,africa,Kenya,Land use changes in the transboundary Mara Basin: a threat to pristine wildlife sanctuaries in East Africa
+24728,Mazaris,2017,Observational,Marine,Global,,Unknown,Unknown,Manifestation of maritime piracy as an additional challenge for global conservation
+24730,Mazor_etal,2017,Observational,Marine,National,0.01,south pacific,Australia,Trawl exposure and protection of seabed fauna at large spatial scales
+24736,Mccauley_etal,2013,Observational,Terrestrial,Sub-national,,north america,United States,Isolated wetland loss and degradation over two decades in an increasingly urbanized landscape
+24739,Mcclanahan,2015,Observational,Marine,Multi-national,,indian ocean,Comoros,Biogeography versus resource management: How do they compare when prioritizing the management of coral reef fish in the south-western Indian Ocean?
+24740,Mcclanahan and Muthiga,2017,Observational,Marine,National,,indian ocean,Mozambique,Environmental variability indicates a climate-adaptive center under threat in northern Mozambique coral reefs
+24738,Mcclanahan_etal,2011,Observational,Marine,Multi-national,,indian ocean,Comoros,Associations between climate stress and coral reef diversity in the western Indian Ocean
+24742,Mcclellan,2009,Observational,Marine,Sub-national,,north atlantic,United States,"Behavior, ecology, and conservation of sea turtles in the North Atlantic Ocean"
+24741,Mcclellan_etal,2009,Observational,Marine,Sub-national,,north atlantic,United States,Using telemetry to mitigate the bycatch of long-lived marine vertebrates
+24743,Mcclintock_etal,2015,Observational,Terrestrial,Sub-national,,north america,United States,Endangered Florida panther population size determined from public reports of motor vehicle collision mortalities
+24745,Mccullough_etal,2017,Observational,Terrestrial,Sub-national,,north america,United States,A range of possibilities: Assessing geographic variation in climate sensitivity of ponderosa pine using tree rings
+24747,Mccune_etal,2019,Observational,Freshwater,National,100,north america,Canada,Are we accurately estimating the potential role of pollution in the decline of species at risk in Canada?
+24748,Mcdonald_etal,2008,Observational,Terrestrial,Global,,Unknown,Unknown,The implications of current and future urbanization for global protected areas and biodiversity conservation
+24750,Mcfadden-Hiller_etal,2016,Observational,Terrestrial,Sub-national,250,north america,United States,Spatial distribution of black bear incident reports in Michigan
+24752,Mcgowan_etal,2013,Observational,Marine,Local,,north pacific,United States,Using Seabird Habitat Modeling to Inform Marine Spatial Planning in Central California's National Marine Sanctuaries
+24754,Mcintyre_etal,2016,Observational,Freshwater,Global,100,Unknown,Unknown,Linking freshwater fishery management to global food security and biodiversity conservation
+24761,Meager_etal,2012,Observational,Terrestrial,Local,0.25,australasia,Australia,Humans alter habitat selection of birds on ocean-exposed sandy beaches
+24765,Meentemeyer_etal,2011,Observational,Terrestrial,Local,250,north america,United States,Epidemiological modeling of invasion in heterogeneous landscapes: Spread of sudden oak death in California (1990-2030)
+24766,Mehri_etal,2019,Observational,Freshwater,Sub-national,30,asia,Iran,Integration of anthropogenic threats and biodiversity value to identify critical sites for biodiversity conservation
+24769,Meijaard_etal,2011,Observational,Terrestrial,Sub-national,,asia,Indonesia,"Quantifying killing of orangutans and human-orangutan conflict in Kalimantan, Indonesia"
+24772,Mellin_etal,2016,Observational,Marine,Continental,81,indian ocean,Unknown,Humans and seasonal climate variability threaten large-bodied coral reef fish with small ranges
+24773,Mellin_etal,2019,Observational,Marine,Sub-national,0.01,south pacific,Australia,Spatial resilience of the Great Barrier Reef under cumulative disturbance impacts
+24776,Menegon_etal,2018,Observational,Marine,Multi-national,500,mediterranean,Italy,"Addressing cumulative effects, maritime conflicts and ecosystem services threats through MSP-oriented geospatial webtools"
+24777,Menegon_etal,2018,Observational,Marine,Sub-national,400,mediterranean,Italy,A modelling framework for MSP-oriented cumulative effects assessment
+24785,Metzger_etal,2010,Observational,Terrestrial,Sub-national,25,africa,Tanzania,Evaluating the protection of wildlife in parks: The case of African buffalo in Serengeti
+24788,Meynecke and Meager,2016,Observational,Marine,Sub-national,,south pacific,Australia,"Understanding Strandings: 25 years of Humpback Whale (Megaptera novaeangliae) Strandings in Queensland, Australia"
+24789,Mezgebu and Workineh,2017,Observational,Terrestrial,Local,30,africa,Ethiopia,"Changes and drivers of afro-alpine forest ecosystem: future trajectories and management strategies in Bale eco-region, Ethiopia"
+24790,Micheli_etal,2013,Observational,Marine,Multi-national,1,mediterranean,Bosnia and Herzegovina,Cumulative human impacts on Mediterranean and Black Sea marine ecosystems: Assessing current pressures and opportunities
+24796,Mijele_etal,2013,Observational,Terrestrial,Local,,africa,Kenya,Spatio-Temporal Distribution of Injured Elephants in Masai Mara and the Putative Negative and Positive Roles of the Local Community
+24806,Milne_etal,2015,Observational,Terrestrial,Sub-national,0.5,africa,South Africa,The role of thermal physiology in recent declines of birds in a biodiversity hotspot
+24811,Miranda_etal,2020,Observational,Terrestrial,Sub-national,,south america,Chile,Forest browning trends in response to drought in a highly threatened mediterranean landscape of South America
+24812,Miranda_etal,2020,Observational,Terrestrial,Local,,south america,Brazil,Are Roadkill Hotspots in the Cerrado Equal Among Groups of Vertebrates?
+24813,Mirrasooli_etal,2019,Observational,Marine,Multi-national,,caspian sea,Iran,Factors associated with illegal fishing and fisher attitudes toward sturgeon conservation in the southern Caspian Sea
+24819,Mo_etal,2017,Observational,Terrestrial,Sub-national,m,asia,China,"Impacts of road network expansion on landscape ecological risk in a megacity, China: A case study of Beijing"
+24821,Mockrin_etal,2008,Observational,Terrestrial,Local,,africa,Congo,"The spatial structure and sustainability of subsistence wildlife harvesting in Kabo, Congo"
+24822,Mockrin_etal,2011,Observational,Terrestrial,Local,,africa,Congo,Effects of Landscape Features on the Distribution and Sustainability of Ungulate Hunting in Northern Congo
+24825,Mohammadi and Kaboli,2016,Observational,Terrestrial,Local,,asia,Iran,Evaluating wildlife-vehicle collision hotspots using kernel-based estimation: A focus on the endangered Asiatic cheetah in central Iran
+24826,Mohammadi_etal,2018,Observational,Terrestrial,Local,30,asia,Iran,"Road expansion: A challenge to conservation of mammals, with particular emphasis on the endangered Asiatic cheetah in Iran"
+24829,Mojica_etal,2016,Observational,Terrestrial,Sub-national,1,north america,United States,Utilization probability map for migrating bald eagles in northeastern North America: A tool for siting wind energy facilities and other flight hazards
+24832,Molinario_etal,2020,Observational,Terrestrial,Sub-national,30,africa,DRC,Contextualizing Landscape-Scale Forest Cover Loss in the Democratic Republic of Congo (DRC) between 2000 and 2015
+24839,Monahan and Fisichelli,2014,Observational,Terrestrial,National,,north america,United States,Climate exposure of US National Parks in a new era of change
+24842,Mondal and Zhang,2018,Observational,Terrestrial,Sub-national,,asia,India,Research progress on changes in land use and land cover in the Western Himalayas (India) and effects on ecosystem services
+24841,Mondal_etal,2017,Observational,Freshwater,Local,,asia,India,"Urban expansion and wetland shrinkage estimation using a GIS-based model in the East Kolkata Wetland, India"
+W26572,Moneron_etal,2017,Observational,Terrestrial,Global,,africa,Unknown,"Pendants, Powder, and Pathways"
+24843,Monette Dean,2014,Observational,Freshwater,Local,,north america,United States,"Resource use, competition, grazing behavior, and ecosystem invasion impacts of <i>Pomacea maculata</i>"
+24847,Monteiro_etal,2018,Observational,Terrestrial,Local,100,south america,Brazil,Conservation priorities for the threatened flora of mountaintop grasslands in Brazil
+24849,Montevecchi_etal,2012,Observational,Marine,Sub-national,,north atlantic,Canada,Tracking seabirds to identify ecologically important and high risk marine areas in the western North Atlantic
+24853,Moody_etal,2017,Observational,Freshwater,Sub-national,,north america,United States,Invasion hotspots and ecological saturation of streams across the Hawaiian archipelago
+24856,Mora,2018,Observational,Terrestrial,National,1,north america,Mexico,A spatial framework for detecting anthropogenic impacts on predator-prey interactions that sustain ecological integrity in Mexico
+24857,Moraes_etal,2017,Observational,Terrestrial,Local,m,south america,Brazil,Protected areas and agricultural expansion: Biodiversity conservation versus economic growth in the Southeast of Brazil
+24858,Moraes_etal,2019,Observational,Terrestrial,National,1,south america,Brazil,Predicting the potential hybridization zones between native and invasive marmosets within Neotropical biodiversity hotspots
+24862,Moran and Kanemoto,2016,Observational,Freshwater,Global,,Unknown,Unknown,Identifying the Species Threat Hotspots from Global Supply Chains
+24863,Moran_etal,2019,Observational,Freshwater,Global,5,Unknown,Unknown,Do amphibians and cash crops compete for scarce water? A spatial correlation analysis
+24867,Moreira_etal,2018,Observational,Terrestrial,Local,5,europe,Portugal,"Spatial assessment of habitat conservation status in a Macaronesian island based on the InVEST model: a case study of Pico Island (Azores, Portugal)"
+24868,Morelli_etal,2020,Observational,Terrestrial,Continental,2500,europe,Unknown,A forecasting map of avian roadkill-risk in Europe: A tool to identify potential hotspots
+24871,Morgan_etal,2013,Observational,Terrestrial,Sub-national,,africa,Cameroon,"The Distribution, Status, and Conservation Outlook of the Drill (Mandrillus leucophaeus) in Cameroon"
+24875,Morrison_etal,2018,Experimental,Terrestrial,Local,30,africa,Kenya,Detecting vegetation change in response to confining elephants in forests using MODIS time-series and BFAST
+24877,Morton_etal,2011,Observational,Marine,Local,,north pacific,Canada,Sea lice dispersion and salmon survival in relation to salmon farm activity in the Broughton Archipelago
+24878,Mosbahi_etal,2019,Observational,Marine,Local,,mediterranean,Tunisia,"Response of benthic macrofauna to multiple anthropogenic pressures in the shallow coastal zone south of Sfax (Tunisia, central Mediterranean Sea)"
+24879,Moullec_etal,2019,Observational,Marine,Multi-national,400,africa,Bosnia and Herzegovina,Capturing the big picture of Mediterranean marine biodiversity with an end-to-end model of climate and fishing impacts
+24881,Mozumder_etal,2014,Observational,Freshwater,Local,,asia,India,Ecosystem evaluation (1989-2012) of Ramsar wetland Deepor Beel using satellite-derived indices
+24885,Mucientes_etal,2009,Observational,Marine,Continental,5,north pacific,Unknown,Sexual segregation of pelagic sharks and the potential threat from fisheries
+24886,Mucova_etal,2018,Observational,Terrestrial,Local,60,africa,Mozambique,"Assessment of land use and land cover changes from 1979 to 2017 and biodiversity & land management approach in Quirimbas National Park, Northern Mozambique, Africa"
+24888,Muhlfeld_etal,2016,Observational,Freshwater,Local,,north america,United States,Genetic Status and Conservation of Westslope Cutthroat Trout in Glacier National Park
+24892,Mullet_etal,2017,Observational,Terrestrial,Local,,north america,United States,Acoustic Footprint of Snowmobile Noise and Natural Quiet Refugia in an Alaskan Wilderness
+24894,Munanura_etal,2013,Observational,Terrestrial,Local,,africa,Rwanda,Managing tourism growth in endangered species' habitats of Africa: Volcanoes National Park in Rwanda
+24895,Munguía_etal,2016,Observational,Terrestrial,National,1,south america,Mexico,Human impact gradient on mammalian biodiversity
+24897,Muñoz_etal,2018,Observational,Marine,Multi-national,1,mediterranean,Spain,A spatial risk approach towards integrated marine spatial planning: A case study on European hake nursery areas in the North Alboran Sea
+24900,Munteanu_etal,2018,Observational,Terrestrial,Multi-national,2,europe,Austria,Bird conservation in the Carpathian Ecoregion in light of long-term land use trends and conservation responsibility
+24901,Murguía_etal,2016,Observational,Terrestrial,Global,,Unknown,Unknown,Global direct pressures on biodiversity by large-scale metal mining: Spatial distribution and implications for conservation
+26902,Murillo_et al,2008,Observational,Marine,Multi-national,,arctic ocean,Greenland,Preliminary data on cold-water corals and large sponges by-catch from Spanish/EU bottom trawl groundfish surveys in NAFO Regulatory Area (Divs. 3LMNO) and Canadian EEZ (Div. 3L): 2005-2007 period
+24903,Murray_etal,2011,Observational,Freshwater,National,250,australasia,Australia,"Assessing spatial patterns of disease risk to biodiversity: Implications for the management of the amphibian pathogen, Batrachochytrium dendrobatidis"
+24912,Mutnale_etal,2018,Observational,Freshwater,Multi-national,,asia,India,Enzootic frog pathogen Batrachochytrium dendrobatidis in Asian tropics reveals high ITS haplotype diversity and low prevalence
+24913,Mwendwa_etal,2020,Observational,Terrestrial,Local,,africa,Tanzania,"Spatio-temporal invasion dynamics of Maesopsis eminii in Amani Nature Forest Reserve, Tanzania"
+24917,Naderi_etal,2018,Observational,Terrestrial,National,,asia,Iran,Persian leopard’s (Panthera pardus saxicolor) unnatural mortality factors analysis in Iran
+24902,Nagabhatla,2007,Observational,Freshwater,Global,500,asia,India,Using geospatial tools to overcoming sustainability concerns for wetland ecosystem
+24920,Nagarajan_etal,2016,Observational,Terrestrial,Local,,asia,India,"Spatial and dietary overlap between blackbuck (Antilope cervicapra) and feral horse (Equus caballus) at Point Calimere Wildlife Sanctuary, Southern India: Competition between native versus introduced species"
+24929,Nath_etal,2019,Observational,Terrestrial,Local,1,asia,India,"In search of Aliens: Factors influencing the distribution of Chromolaena odorata L. and Mikania micrantha Kunth in the Terai grasslands of Manas National Park, India"
+24930,Naura_etal,2016,Observational,Freshwater,National,1,europe,United Kingdom,Mapping the combined risk of agricultural fine sediment input and accumulation for riverine ecosystems across England and Wales
+24935,Nazaro_etal,2020,Observational,Terrestrial,Multi-national,441,south america,Argentina,"Untangling the imprints of climate, geography and land use/cover on bird diversity in the South American Gran Chaco"
+24937,Negret_etal,2019,Observational,Terrestrial,National,10,south america,Colombia,Emerging evidence that armed conflict and coca cultivation influence deforestation patterns
+24944,Nelson and Burnside,2019,Observational,Marine,Local,1,north atlantic,United Kingdom,Identification of marine management priority areas using a GIS-based multi-criteria approach
+24943,Nelson_etal,2015,Observational,Terrestrial,Local,,north america,Canada,A time geographic approach for delineating areas of sustained wildlife use
+24945,Nematollahi_etal,2020,Observational,Terrestrial,Sub-national,1,asia,Iran,"Application of InVEST habitat quality module in spatially vulnerability assessment of natural habitats (case study: Chaharmahal and Bakhtiari province, Iran)"
+24951,Neumann_etal,2017,Observational,Marine,National,400,north atlantic,Germany,Full-coverage spatial distribution of epibenthic communities in the south-eastern North Sea in relation to habitat characteristics and fishing effort
+24956,Newell,2011,Observational,Terrestrial,Local,,australasia,Australia,Recent invasions of World Heritage rainforests in north-east New South Wales by the cane toad Bufo marinus
+24959,Nguyen,2017,Observational,Terrestrial,Local,0.5,asia,Brunei,Ecological Impacts of Deforestation and Forest Degradation in the Peat Swamp Forests of Northwestern Borneo
+24962,Nickel Barry_etal,2020,Observational,Terrestrial,Local,1,north america,United States,Human presence and human footprint have non-equivalent effects on wildlife spatiotemporal habitat use
+24963,Nielsen_etal,2004,Observational,Terrestrial,Sub-national,,north america,Canada,Modelling the spatial distribution of human-caused grizzly bear mortalities in the Central Rockies ecosystem of Canada
+24966,Nieman_etal,2019,Observational,Terrestrial,Local,,africa,South Africa,Socioeconomic and biophysical determinants of wire-snare poaching incidence and behaviour in the Boland Region of South Africa
+24971,Niphadkar_etal,2017,Observational,Terrestrial,Local,2,asia,India,Comparing pixel and object-based approaches to map an understorey invasive shrub in tropical mixed forests
+24974,Nituch_etal,2011,Observational,Terrestrial,Sub-national,,north america,Canada,Mink farms predict aleutian disease exposure in wild american mink
+24977,Noble_etal,2020,Observational,Marine,Local,,south pacific,Australia,Identifying spatial conservation priorities using Traditional and Local Ecological Knowledge of iconic marine species and ecosystem threats
+24978,Nogueira_etal,2010,Observational,Freshwater,National,,south america,Brazil,Restricted-range fishes and the conservation of Brazilian freshwaters
+24991,Northrup_etal,2019,Observational,Terrestrial,Sub-national,,north america,United States,Synergistic effects of climate and land-use change influence broad-scale avian population declines
+W26573,Nowell_etal,2016,Observational,Terrestrial,Multi-national,,asia,Afghanistan,An ounce of Prevention: Snow Leopard Crime Revisited
+25005,O’leary_etal,2019,S_Review,Marine,Multi-national,,indian ocean,Gibraltar,Evidence gaps and biodiversity threats facing the marine environment of the United Kingdom’s Overseas Territories
+25008,Obusan_etal,2016,Observational,Marine,National,,south china sea,Philippines,Stranding events in the Philippines provide evidence for impacts of human interactions on cetaceans
+25010,Ochoa-Ochoa_etal,2011,Observational,Freshwater,National,,north america,Mexico,Choosing the survivors? A GIS-based triage support tool for micro-endemics: Application to data for Mexican amphibians
+25012,O'farrell_etal,2010,Observational,Terrestrial,Sub-national,,africa,South Africa,Multi-functional landscapes in semi arid environments: Implications for biodiversity and ecosystem services
+25026,Ondei_etal,2019,Observational,Terrestrial,National,,australasia,Australia,"A flexible tool to prioritize areas for conservation combining landscape units, measures of biodiversity, and threats"
+25028,Onmu? and Siki,2013,Observational,Freshwater,Local,1,asia,Turkey,Impacts of anthropogenic activities and habitat degradation on breeding waterbirds
+25030,Onyia_etal,2018,Experimental,Terrestrial,Local,,africa,Nigeria,Normalized difference vegetation vigour index: A new remote sensing approach to biodiversity monitoring in oil polluted regions
+W26582,Opperman_etal,2019,Observational,Freshwater,Multi-national,,asia,Myanmar,"Connected and flowing: a renewable future for rivers, climate and people"
+25033,Orgiazzi_etal,2016,Observational,Terrestrial,Continental,500,europe,Unknown,A knowledge-based approach to estimating the magnitude and spatial patterns of potential threats to soil biodiversity
+25037,Ortiz Andrea,2019,Observational,Terrestrial,National,,asia,Philippines,Assessing the impacts of agriculture and its trade on Philippine biodiversity
+25042,Overmars_etal,2014,Observational,Freshwater,Continental,2500,europe,Unknown,Developing a methodology for a species-based and spatially explicit indicator for biodiversity on agricultural land in the EU
+25049,Padalia and Bahuguna,2017,Observational,Terrestrial,Sub-national,km2,asia,India,Spatial modelling of congruence of native biodiversity and potential hotspots of forest invasive species (FIS) in central Indian landscape
+25051,Paffetti_etal,2018,Observational,Terrestrial,Local,1,europe,Italy,Land use and wind direction drive hybridization between cultivated poplar and native species in a Mediterranean floodplain environment
+25052,Pairaud_etal,2014,Observational,Marine,Multi-national,100,mediterranean,France,"Impacts of climate change on coastal benthic ecosystems: Assessing the current risk of mortality outbreaks associated with thermal stress in NW Mediterranean coastal areas Topical Collection on the 16th biennial workshop of the Joint Numerical Sea Modelling Group (JONSMOD) in Brest, France 21-23 May 2012"
+25054,Palacios-Torres_etal,2020,Observational,Freshwater,Sub-national,,south america,Colombia,Trace elements in sediments and fish from Atrato River: an ecosystem with legal rights impacted by gold mining at the Colombian Pacific
+25058,Paniw_etal,2015,Observational,Terrestrial,Multi-national,250,africa,Spain,"Local-scale disturbances can benefit an endangered, fire-adapted plant species in Western Mediterranean heathlands in the absence of fire"
+25059,Panlasigui_etal,2018,Observational,Freshwater,National,,north america,United States,Assessing threats of non-native species to native freshwater biodiversity: Conservation priorities for the United States
+25061,Paredes_etal,2019,Observational,Freshwater,Local,,europe,Spain,Stable isotopes in helophytes reflect anthropogenic nitrogen pollution in entry streams at the Doñana World Heritage Site
+25065,Parmenter_etal,2003,Observational,Terrestrial,Sub-national,2.25,north america,United States,Land use and land cover change in the Greater Yellowstone Ecosystem: 1975-1995
+25066,Parnell_etal,2010,Observational,Marine,Local,,north atlantic,United States,Spatial patterns of fishing effort off San Diego: Implications for zonal management and ecosystem function
+25067,Parravicini_etal,2012,Observational,Marine,Local,250,mediterranean,Italy,Understanding relationships between conflicting human uses and coastal ecosystems status: A geospatial modeling approach
+25068,Parry_etal,2009,Observational,Terrestrial,Local,,south america,Brazil,Allocation of hunting effort by Amazonian smallholders: Implications for conserving wildlife in mixed-use landscapes
+25071,Parsons_etal,2014,Observational,Terrestrial,Local,,africa,Tanzania,Global positioning system data-loggers: A tool to quantify fine-scale movement of Domestic animals to evaluate potential for zoonotic transmission to an endangered wildlife population
+25072,Partelow_etal,2015,Observational,Marine,Global,,Unknown,Unknown,Pollution exposure on marine protected areas: A global assessment
+25073,Paschoalini_etal,2020,Observational,Freshwater,Local,,south america,Brazil,On the brink of isolation: Population estimates of the Araguaian river dolphin in a human-impacted region in Brazil
+25075,Pascual-Rico_etal,2020,Observational,Terrestrial,Local,,europe,Spain,Ecological niche overlap between co-occurring native and exotic ungulates: insights for a conservation conflict
+25076,Pasha_etal,2020,Observational,Terrestrial,Sub-national,23.5,asia,India,Assessment of shifting cultivation fallows in Northeastern India using Landsat imageries
+25077,Pasher_etal,2013,Observational,Terrestrial,Sub-national,30,north america,Canada,Development of boreal ecosystem anthropogenic disturbance layers for Canada based on 2008 to 2010 Landsat imagery
+25078,Pasqualini_etal,2011,Observational,Terrestrial,Local,,europe,France,"A GIS-based multicriteria evaluation for aiding risk management Pinus pinaster Ait. Forests: A case study in Corsican island, western Mediterranean region"
+25080,Patino and Estupinan-Suarez,2016,Observational,Freshwater,National,100,south america,Colombia,Hotspots of Wetland Area Loss in Colombia
+25082,Patrizzi and Dobrovolski,2018,Observational,Marine,National,5,north atlantic,Brazil,Integrating climate change and human impacts into marine spatial planning: A case study of threatened starfish species in Brazil
+25084,Pattanaik_etal,2011,Observational,Terrestrial,Local,80,asia,India,"Assessment of spatial and temporal dynamics of tropical forest cover: A case study in Malkangiri district of Orissa, India"
+25083,Pattanaik_etal,2008,Observational,Terrestrial,Local,57,asia,India,"Mapping, monitoring and conservation of Malianandi wetland ecosystem, Orissa, India using remote sensing and GIS"
+25086,Patthey_etal,2008,Experimental,Terrestrial,Local,625,europe,Switzerland,Impact of outdoor winter sports on the abundance of a key indicator species of alpine ecosystems
+25088,Pauchard_etal,2003,Observational,Terrestrial,Local,,north america,United States,Plant invasions in protected areas at multiple scales: Linaria vulgaris (Scrophulariaceae) in the West Yellowstone area
+25089,Paudel,2012,Observational,Terrestrial,Local,,asia,Nepal,Challenges to wildlife conservation posed by hunting in non-protected areas north of the Bardia national park
+25099,Peck_etal,2011,Observational,Terrestrial,Sub-national,,south america,Ecuador,"Focusing Conservation Efforts for the Critically Endangered Brown-headed Spider Monkey (Ateles fusciceps) Using Remote Sensing, Modeling, and Playback Survey Methods"
+25101,Pedroni ,2010,Observational,Terrestrial,Multi-national,,north america,Ecuador,Delivering in sensitive environments: Incorporating biodiversity and ecosystem conservation into operations
+25112,Penney and Guinotte,2013,Observational,Marine,Sub-national,1,south pacific,New Zealand,Evaluation of New Zealand's high-seas bottom trawl closures using predictive habitat models and quantitative risk assessment
+25114,Pennino_etal,2017,Observational,Marine,Sub-national,16,mediterranean,Italy,A spatially explicit risk assessment approach: Cetaceans and marine traffic in the Pelagos Sanctuary (Mediterranean Sea)
+25118,Peregrym_etal,2020,Observational,Marine,Multi-national,,mediterranean,Italy,How are the Mediterranean islands polluted by artificial light at night?
+25120,Pereira_etal,2020,Observational,Terrestrial,Local,,south america,Brazil,"Electrocutions in free-living black-tufted marmosets (Callithrix penicillata) in anthropogenic environments in the Federal District and surrounding areas, Brazil"
+25122,Pérez-García_etal,2017,Observational,Terrestrial,Sub-national,1,europe,Spain,Using risk prediction models and species sensitivity maps for large-scale identification of infrastructure-related wildlife protection areas: The case of bird electrocution
+25123,Périquet_etal,2018,Observational,Terrestrial,National,,africa,South Africa,Testing the value of citizen science for roadkill studies: A case study from South Africa
+25124,Peristeraki_etal,2020,Observational,Marine,Multi-national,,mediterranean,Turkey,The effect of bottom trawl fishery on biomass variations of demersal chondrichthyes in the eastern Mediterranean
+25127,Pertierra_etal,2017,Observational,Terrestrial,National,2500,antarctica,Antarctica,High resolution spatial mapping of human footprint across antarctica and its implications for the strategic conservation of avifauna
+25130,Peterson_etal,2006,Observational,Terrestrial,Sub-national,,north america,United States,"Genetically engineered plants, endangered species, and risk: A temporal and spatial exposure assessment for karner blue butterfly larvae and Bt maize pollen"
+25133,Petit and Elbersen,2006,Observational,Terrestrial,Continental,25,europe,Unknown,Assessing the risk of impact of farming intensification on calcareous grasslands in Europe: A quantitative implementation of the MIRABEL framework
+25137,Petrossian,2015,Observational,Marine,Global,,Unknown,Unknown,"Preventing illegal, unreported and unregulated (IUU) fishing: A situational approach"
+25138,Petrozzi_etal,2018,Observational,Terrestrial,Multi-national,100,africa,Algeria,Exploring the main threats to the threatened African spurred tortoise Centrochelys sulcata in the West African Sahel
+25139,Petz_etal,2014,Observational,Terrestrial,Global,30,Unknown,Unknown,Mapping and modelling trade-offs and synergies between grazing intensity and ecosystem services in rangelands using global-scale datasets and models
+25145,Phipps_etal,2013,Observational,Terrestrial,Multi-national,,africa,Botswana,Do Power Lines and Protected Areas Present a Catch-22 Situation for Cape Vultures (Gyps coprotheres)?
+25146,Phoenix_etal,2006,Observational,Terrestrial,Global,5,Unknown,Unknown,Atmospheric nitrogen deposition in world biodiversity hotspots: The need for a greater global perspective in assessing N deposition impacts
+25150,Pidgeon_etal,2015,Observational,Terrestrial,Multi-national,,south america,Bolivia,Will representation targets based on area protect critical resources for the conservation of the Tucuman Parrot?
+25153,Pierre_etal,2018,Observational,Terrestrial,Sub-national,1,north america,United States,"Comparison of Recent Oil and Gas, Wind Energy, and Other Anthropogenic Landscape Alteration Factors in Texas Through 2014"
+25156,Pikesley_etal,2015,Observational,Marine,Multi-national,81,north atlantic,Cape Verde,"Modelling the niche for a marine vertebrate: A case study incorporating behavioural plasticity, proximate threats and climate change"
+25157,Pikesley_etal,2016,Observational,Marine,Sub-national,200,north atlantic,United Kingdom,Pink sea fans (Eunicella verrucosa) as indicators of the spatial efficacy of Marine Protected Areas in southwest UK coastal waters
+25158,Pilcher_etal,2017,Observational,Marine,National,,south china sea,Thailand,A low-cost solution for documenting distribution and abundance of endangered marine fauna and impacts from fisheries
+25159,Pilot_etal,2018,Observational,Terrestrial,Continental,,asia,Unknown,"Widespread, long-term admixture between grey wolves and domestic dogs across Eurasia and its implications for the conservation status of hybrids"
+25162,Pinho_etal,2018,Observational,Terrestrial,National,,europe,Portugal,Mapping Portuguese Natura 2000 sites in risk of biodiversity change caused by atmospheric nitrogen pollution
+25165,Pinto_etal,2020,Observational,Terrestrial,Continental,10000,south america,Unknown,Effects of roads on terrestrial vertebrate species in Latin America
+25166,Piqueray_etal,2008,Observational,Terrestrial,National,,europe,Belgium,"Naturalization and impact of a horticultural species, cotoneaster horizontalis (rosaceae) in biodiversity hotspots in Belgium"
+25169,Pirotta_etal,2018,Observational,Marine,Sub-national,30,arctic ocean,Canada,Modelling beluga habitat use and baseline exposure to shipping traffic to design effective protection against prospective industrialization in the Canadian Arctic
+25172,Pitman_etal,2015,Observational,Terrestrial,Sub-national,,africa,South Africa,"The importance of refugia, ecological traps and scale for large carnivore management"
+25175,Plaza_etal,2019,Observational,Terrestrial,Global,,Unknown,Unknown,The perfect threat: Pesticides and vultures
+25178,Plumptre_etal,2014,Observational,Terrestrial,Multi-national,62500,africa,Burundi,Efficiently targeting resources to deter illegal activities in protected areas
+25182,Polaina_etal,2016,Observational,Terrestrial,Global,1,Unknown,Unknown,"Putting susceptibility on the map to improve conservation planning, an example with terrestrial mammals"
+25188,Ponnampalam_etal,2015,Observational,Marine,Local,,south china sea,Malaysia,"Aligning conservation and research priorities for proactive species and habitat management: The case of dugongs Dugong dugon in Johor, Malaysia"
+25189,Pontius_etal,2008,Observational,Terrestrial,Sub-national,1,north america,United States,"Ash decline assessment in emerald ash borer-infested regions: A test of tree-level, hyperspectral technologies"
+25190,Poor_etal,2019,Observational,Terrestrial,Local,30,asia,Indonesia,"The road to deforestation: Edge effects in an endemic ecosystem in Sumatra, Indonesia"
+25191,Poos_etal,2010,Observational,Freshwater,Sub-national,,north america,Canada,Secondary invasion of the round goby into high diversity Great Lakes tributaries and species at risk hotspots: Potential new concerns for endangered freshwater species
+25193,Porobic_etal,2019,Observational,Marine,Sub-national,,south pacific,Chile,"The impact of fishing on a highly vulnerable ecosystem, the case of Juan Fernández Ridge ecosystem"
+25200,Potter_etal,2019,Observational,Terrestrial,National,,north america,United States,Important insect and disease threats to United States tree species and geographic patterns of their potential impacts
+25211,Preece,2007,Observational,Terrestrial,Local,500,australasia,Australia,Identifying hotspots for threats to koalas using spatial analysis
+25216,Pretorius_etal,2019,Observational,Terrestrial,Sub-national,,africa,South Africa,Landscape correlates of space use in the critically endangered African wild dog Lycaon pictus
+25221,Price_etal,2011,Observational,Freshwater,Sub-national,,north america,Canada,Sea louse infection of juvenile sockeye salmon in relation to marine salmon farms on Canada's west coast
+25223,Proctor_etal,2015,Observational,Terrestrial,Sub-national,,north america,Canada,Grizzly bear connectivity mapping in the Canada-United States trans-border region
+25225,Prosser_etal,2016,Observational,Terrestrial,National,1,asia,China,Spatial modeling of wild bird risk factors for highly pathogenic a(H5N1) avian influenza virus transmission
+25229,Pullanikkatil_etal,2016,Observational,Freshwater,Local,,africa,Malawi,"Assessment of land use change in Likangala River catchment, Malawi: A remote sensing and DPSIR approach"
+25230,Pullanikkatil_etal,2020,Observational,Freshwater,Local,,africa,Malawi,Unsustainable trade-offs: provisioning ecosystem services in rapidly changing Likangala River catchment in southern Malawi
+25232,Pupina_etal,2018,Observational,Freshwater,National,arc-minutes,europe,Latvia,"Species distribution modelling: Bombina bombina (linnaeus, 1761) and its important invasive threat perccottus glenii (dybowski, 1877) in Latvia under global climate change"
+25233,Purroy_etal,2014,Observational,Marine,Local,500,mediterranean,Spain,Spatial assessment of artisanal fisheries and their potential impact on the seabed: the Cap de Creus regional case study (northwestern Mediterranean Sea)
+25234,Pusparini_etal,2018,Observational,Terrestrial,Local,,asia,Indonesia,A pathway to recovery: The Critically Endangered Sumatran tiger Panthera tigris sumatrae in an 'in danger' UNESCO World Heritage Site
+25240,Qiuqin and Tianzhu,2018,Observational,Terrestrial,Local,,asia,China,Land consolidation design based on an evaluation of ecological sensitivity
+25241,Qu_etal,2018,Observational,Terrestrial,Sub-national,1,asia,China,"What drives the vegetation restoration in Yangtze River basin, China: Climate change or anthropogenic factors?"
+25242,Quadroni_etal,2017,Observational,Freshwater,Local,,europe,Italy,Response of stream benthic macroinvertebrates to current water management in Alpine catchments massively developed for hydropower
+25246,Queiroz_etal,2016,Observational,Marine,Global,1,Unknown,Unknown,Ocean-wide tracking of pelagic sharks reveals extent of overlap with longline fishing hotspots
+25247,Queiroz_etal,2019,Observational,Marine,Global,1,Unknown,Unknown,Global spatial risk assessment of sharks under the footprint of fisheries
+25266,Rahman_etal,2020,S_Review,Freshwater,Continental,,asia,Unknown,Chytrid infection in asia: How much do we know and what else do we need to know?
+25268,Raimondo_etal,2019,Observational,Freshwater,Sub-national,,north america,United States,A unified approach for protecting listed species and ecosystem services in isolated wetlands using community-level protection goals
+25270,Rajah_etal,2020,Observational,Terrestrial,Local,20,africa,South Africa,Assessing the synergistic potential of Sentinel-2 spectral reflectance bands and derived vegetation indices for detecting and mapping invasive alien plant species
+25274,Ramachandra_etal,2016,Observational,Terrestrial,Sub-national,,asia,India,"Geospatial analysis of forest fragmentation in Uttara Kannada District, India"
+25275,Ramachandra_etal,2018,Observational,Terrestrial,Local,,asia,India,"Modelling landscape dynamics with LST in protected areas of Western Ghats, Karnataka"
+25276,Ramachandran_etal,2018,Observational,Terrestrial,Sub-national,,asia,India,"Long-term land use and land cover changes (1920–2015) in Eastern Ghats, India: Pattern of dynamics and challenges in plant species conservation"
+25278,Ramirez_etal,2018,Observational,Marine,Multi-national,0.25,mediterranean,Bosnia and Herzegovina,Spatial congruence between multiple stressors in the Mediterranean Sea may reduce its resilience to climate impacts
+25283,Ramirez-Villegas_etal,2012,Observational,Terrestrial,Continental,0.5,south america,Unknown,Analysis of threats to South American flora and its implications for conservation
+25286,Ramos-Merchante and Prenda,2018,Observational,Freshwater,Sub-national,,europe,Spain,The Ecological and Conservation Status of The Guadalquivir River Basin (s Spain) Through The Application Of A Fish-based Multimetric Index
+25287,Ramp_etal,2006,Observational,Terrestrial,Local,300,australasia,Australia,"Assessing the impacts of roads in peri-urban reserves: Road-based fatalities and road usage by wildlife in the Royal National Park, New South Wales, Australia"
+25292,Rao and Pant,2001,Observational,Freshwater,Local,,asia,India,"Land use dynamics and landscape change pattern in a typical micro watershed in the mid elevation zone of central Himalaya, India"
+25296,Rashid_etal,2013,Observational,Terrestrial,Sub-national,,asia,India,"Geospatial modelling approach for identifying disturbance regimes and biodiversity rich areas in North Western Himalayas, India"
+25297,Rashid_etal,2020,Observational,Terrestrial,Local,30,asia,Bangladesh,Spatiotemporal changes of vegetation and land surface temperature in the refugee camps and its surrounding areas of Bangladesh after the Rohingya influx from Myanmar
+25298,Rashidi_etal,2016,Observational,Terrestrial,Sub-national,,africa,Kenya,Elephant poaching risk assessed using spatial and non-spatial Bayesian models
+25299,Rasmussen_etal,2013,Observational,Freshwater,Local,,europe,Denmark,A catchment scale evaluation of multiple stressor effects in headwater streams
+W26590,Ratsimbazafy_etal,2016,Observational,Marine,Local,,indian ocean,Madagascar,Fishing site mapping using local knowledge provides accurate and satisfactory results: case study of octopus fisheries in Madagascar
+25304,Rattner_etal,2000,S_Review,Terrestrial,Sub-national,,north atlantic,United States,Contaminant Exposure and Effects - Terrestrial Vertebrates database: Trends and data gaps for Atlantic coast estuaries
+25308,Rayan and Linkie,2015,Observational,Terrestrial,Local,4,asia,Malaysia,Conserving tigers in Malaysia: A science-driven approach for eliciting conservation policy change
+25309,Razgour_etal,2018,Observational,Terrestrial,Multi-national,1,europe,United Kingdom,An integrated framework to identify wildlife populations under threat from climate change
+25313,Reddy_etal,2014,Observational,Terrestrial,Sub-national,25,asia,India,"Threat evaluation for biodiversity conservation of forest ecosystems using geospatial techniques: A case study of Odisha, India"
+25315,Redfern_etal,2012,Observational,Marine,Sub-national,4,north pacific,United States,Assessing the Risk of Ships Striking Large Whales in Marine Spatial Planning
+25317,Reece_etal,2013,Observational,Terrestrial,Local,,north atlantic,United States,"Sea level rise, land use, and climate change influence the distribution of loggerhead turtle nests at the largest USA rookery (Melbourne Beach, Florida)"
+25324,Reina-Rodríguez and Soriano,2008,Observational,Marine,Local,,mediterranean,Spain,Diachronic cartography and spatial pattern assessment in coastal habitats: The case of Torredembarra (northeast Spain)
+25327,Reisland and Lambert,2016,Observational,Terrestrial,Local,,asia,Indonesia,Sympatric apes in sacred forests: Shared space and habitat use by humans and endangered javan gibbons (hylobatesmoloch)
+25336,Revuelta_etal,2018,Observational,Marine,Local,,mediterranean,Spain,Interaction between bottlenose dolphins (Tursiops truncatus) and artisanal fisheries in the Valencia region (Spanish Mediterranean Sea)
+25337,Rey_etal,2015,Observational,Freshwater,National,,europe,France,Elucidating the spatio-temporal dynamics of an emerging wildlife pathogen using approximate Bayesian computation
+25350,Ribeiro and Sá-Sousa,2018,Observational,Terrestrial,Local,,europe,Portugal,Where to live in lisbon: Urban habitat used by the introduced italian wall lizard (podarcis siculus)
+25349,Ribeiro_etal,2018,Observational,Freshwater,Sub-national,30,south america,Brazil,Effects of agriculture and topography on tropical amphibian species and communities
+25352,Ribeiro_etal,2019,Observational,Terrestrial,Sub-national,,south america,Brazil,Disturbance or propagule pressure? Unravelling the drivers and mapping the intensity of invasion of free-ranging dogs across the Atlantic forest hotspot
+25355,Richards and Friess,2016,Observational,Terrestrial,Multi-national,1,asia,Indonesia,"Rates and drivers of mangrove deforestation in Southeast Asia, 2000-2012"
+25361,Rifaie_etal,2015,Observational,Terrestrial,Sub-national,,asia,Indonesia,"Spatial point pattern analysis of the sumatran tiger (Panthera tigris sumatrae) poaching cases in and around kerinci seblat national park, sumatra"
+25365,Rija_etal,2020,S_Review,Terrestrial,Global,,Unknown,Unknown,Global extent and drivers of mammal population declines in protected areas under illegal hunting pressure
+25369,Rimal_etal,2018,Observational,Terrestrial,Local,,asia,Nepal,"Habitat suitability and threat analysis of Greater One-horned Rhinoceros Rhinoceros unicornis Linnaeus, 1758 (Mammalia: Perissodactyla: Rhinocerotidae) in Rautahat District, Nepal"
+25371,Riolo,2006,Observational,Marine,National,km,south pacific,American Samoa,A geographic information system for fisheries management in American Samoa
+25372,Ripple_etal,2016,Observational,Terrestrial,Global,,Unknown,Unknown,Bushmeat hunting and extinction risk to the world’s mammals
+25374,Riskas_etal,2016,Observational,Marine,National,1,indian ocean,Australia,Justifying the need for collaborative management of fisheries bycatch: A lesson from marine turtles in Australia
+W26588,Robert I. Mcdonald_etal,2018,Observational,Terrestrial,Global,,Unknown,Unknown,Nature in the Urban Century
+25381,Robertson_etal,2004,Observational,Terrestrial,Multi-national,1,africa,South Africa,A fuzzy classification technique for predicting species' distributions: Applications using invasive alien plants and indigenous insects
+25384,Robillard and Kerr,2016,Observational,Terrestrial,Sub-national,,north america,Canada,Assessing the shelf life of cost-efficient conservation plans for species at risk across gradients of agricultural land use
+25390,Roder_etal,2015,Observational,Terrestrial,Multi-national,30,africa,Namibia,Assessing urban growth and rural land use transformations in a cross-border situation in Northern Namibia and Southern Angola
+25392,Rodrigues_etal,2014,Observational,Terrestrial,Global,,Unknown,Unknown,Spatially explicit trends in the global conservation status of vertebrates
+25391,Rodrigues_etal,2012,Observational,Terrestrial,Sub-national,,europe,Spain,"Remote sensing to map influence of light pollution on Cory's shearwater in São Miguel Island, Azores Archipelago"
+25393,Rodrigues_etal,2014,Observational,Terrestrial,National,1,europe,Spain,Modeling the spatial variation of the explanatory factors of human-caused wildfires in Spain using geographically weightedlogistic regression
+25400,Rodriguez-Merino_etal,2017,Observational,Freshwater,Multi-national,5,europe,Spain,An invasion risk map for non-native aquatic macrophytes of the Iberian Peninsula
+25402,Rodríguez-Rodríguez and Bomhard,2012,Observational,Terrestrial,Global,1,Unknown,Unknown,Mapping direct human influence on the world's mountain areas
+25405,Rodríguez-Teijeiro_etal,2009,Observational,Terrestrial,National,,europe,Spain,The effects of mowing and agricultural landscape management on population movements of the common quail
+25407,Roe_etal,2014,Observational,Marine,Continental,5,north pacific,Unknown,Predicting bycatch hotspots for endangered leatherback turtles on longlines in the Pacific Ocean
+25409,Roger_etal,2011,Observational,Terrestrial,Local,100,australasia,Australia,Road impacts a tipping point for wildlife populations in threatened landscapes
+25410,Roger_etal,2012,Observational,Terrestrial,Local,,australasia,Australia,Linking habitat suitability and road mortalities across geographic ranges
+25411,Rogers_etal,2010,Observational,Terrestrial,National,km,africa,Madagascar,Prioritizing key biodiversity areas in Madagascar by including data on human pressure and ecosystem services
+25413,Román-Palacios and Valencia-Zuleta,2018,Observational,Freshwater,National,0.5,south america,Colombia,Geographical context of forgotten amphibians: Colombian “Data Deficient species” sensu IUCN
+25416,Romero-Muñoz_etal,2019,Observational,Terrestrial,Multi-national,1,south america,Bolivia,Habitat loss and overhunting synergistically drive the extirpation of jaguars from the Gran Chaco
+25417,Romero-Muñoz_etal,2020,Observational,Terrestrial,Multi-national,1,south america,Argentina,Increasing synergistic effects of habitat destruction and hunting on mammals over three decades in the Gran Chaco
+25419,Ropert-Coudert_etal,2019,Observational,Terrestrial,Local,,north america,Mexico,Happy feet in a hostile world? The future of penguins depends on proactive management of current and expected threats
+25420,Rorabaugh_etal,2018,Observational,Freshwater,Sub-national,,north america,Mexico,"Status of the threatened chiricahua leopard frog and conservation challenges in Sonora, Mexico, with notes on other ranid frogs and non-native predators"
+25422,Roscioni_etal,2013,Observational,Terrestrial,Local,,europe,Italy,Regional-scale modelling of the cumulative impact of wind farms on bats
+25431,Rowden_etal,2019,Observational,Marine,National,1,south pacific,New Zealand,Examining the utility of a decision-support tool to develop spatial management options for the protection of vulnerable marine ecosystems on the high seas around New Zealand
+25435,Ruiz-Orejón_etal,2019,Observational,Marine,Sub-national,,mediterranean,Spain,Quarterly variability of floating plastic debris in the marine protected area of the Menorca Channel (Spain)
+25437,Rushton_etal,2006,Observational,Terrestrial,Local,100,europe,United Kingdom,Disease threats posed by alien species: The role of a poxvirus in the decline of the native red squirrel in Britain
+25438,Russo_etal,2020,Observational,Terrestrial,National,,europe,Italy,Prioritizing road-kill mitigation areas: A spatially explicit national-scale model for an elusive carnivore
+25442,Sainsbury_etal,2008,Observational,Terrestrial,National,,europe,United Kingdom,Poxviral disease in red squirrels sciurus vulgaris in the UK: Spatial and temporal trends of an emerging threat
+25443,Saito_etal,2016,Observational,Terrestrial,Local,,asia,Japan,Time-delayed response of Japanese hare distribution to landscape change along an urban gradient
+25444,Sajeev and Subramanian,2003,Observational,Freshwater,Local,,asia,India,Land use/land cover changes in Ashtamudi wetland region of Kerala - A study using remote sensing and GIS
+25447,Sales Naiara_etal,2018,Observational,Freshwater,Sub-national,,south america,Brazil,Introgression from non-native species unveils a hidden threat to the migratory Neotropical fish Prochilodus hartii
+25449,Salgado_etal,2018,Observational,Marine,Sub-national,289,north pacific,United States,"Distribution of deep-water corals, sponges, and demersal fisheries landings in Southern California, USA: Implications for conservation priorities"
+25454,Samhouri and Levin,2012,Observational,Marine,Local,,north pacific,United States,Linking land- and sea-based activities to risk in coastal ecosystems
+25461,Sanchez-Mercado_etal,2008,Observational,Terrestrial,Sub-national,20,south america,Venezuela,"Factors affecting poaching risk to Vulnerable Andean bears Tremarctos ornatus in the Cordillera de Merida, Venezuela: space, parks and people"
+25464,Sangil_etal,2013,Observational,Marine,Local,,north atlantic,Canary Islands,Assessing the impact of fishing in shallow rocky reefs: A multivariate approach to ecosystem management
+25469,Santora_etal,2017,Observational,Marine,Sub-national,4500,north pacific,United States,Persistence of trophic hotspots and relation to human impacts within an upwelling marine ecosystem
+25470,Santora_etal,2020,Observational,Marine,Sub-national,25,north pacific,United States,Habitat compression and ecosystem shifts as potential links between marine heatwave and record whale entanglements
+25473,Santos_etal,2013,Observational,Terrestrial,Local,m,europe,Portugal,"Relative effects of road risk, habitat suitability, and connectivity on wildlife roadkills: The case of tawny owls (Strix aluco)"
+25474,Santos_etal,2013,Observational,Terrestrial,Sub-national,m,europe,Portugal,Using species distribution modelling to predict bat fatality risk at wind farms
+25482,Scabin_etal,2011,Observational,Terrestrial,Local,,south america,Brazil,The spatial distribution of illegal logging in the Anavilhanas archipelago (Central Amazonia) and logging impacts on species
+25488,Scheele_etal,2019,Observational,Freshwater,Global,,Unknown,Unknown,Amphibian fungal panzootic causes catastrophic and ongoing loss of biodiversity
+25487,Scheele_etal,2015,Observational,Freshwater,Local,,europe,Romania,Landscape context influences chytrid fungus distribution in an endangered European amphibian
+25493,Schinegger_etal,2013,Observational,Freshwater,Continental,,europe,Unknown,Pressure-specific and multiple pressure response of fish assemblages in European running waters
+25496,Schlacher_etal,2016,S_Review,Marine,Global,,Unknown,Unknown,Human threats to sandy beaches: A meta-analysis of ghost crabs illustrates global anthropogenic impacts
+25499,Schmeller_etal,2007,Observational,Freshwater,Multi-national,,europe,France,Introducing water frogs - Is there a risk for indigenous species in France?
+25507,Schuette_etal,2016,Observational,Terrestrial,Local,,africa,Kenya,"Ungulate distributions in a rangeland with competitors, predators and pastoralists"
+25511,Schurmann_etal,2020,Observational,Terrestrial,Local,,africa,Kenya,Assessing the relationship between land tenure issues and land cover changes around the Arabuko Sokoke Forest in Kenya
+25512,Schuyler_etal,2014,S_Review,Marine,Global,,Unknown,Unknown,Global Analysis of Anthropogenic Debris Ingestion by Sea Turtles
+25513,Schwartz_etal,2010,Observational,Terrestrial,Sub-national,,north america,United States,Hazards affecting grizzly bear survival in the greater yellowstone ecosystem
+25515,Sciarretta_etal,2016,Observational,Terrestrial,Sub-national,,europe,Italy,Adaptive management of invasive pests in natural protected areas: The case of Matsucoccus feytaudi in Central Italy
+25516,Scolozzi and Geneletti,2011,Observational,Terrestrial,Local,,europe,Italy,Spatial rule-based assessment of habitat potential to predict impact of land use changes on biodiversity at municipal scale
+25518,Seabrook_etal,2011,Observational,Terrestrial,Sub-national,,australasia,Australia,Drought-driven change in wildlife distribution and numbers: a case study of koalas in south west Queensland
+25520,Seidel_etal,2018,Observational,Terrestrial,Sub-national,,europe,Germany,Assessment of roe deer (Capreolus capreolus L.) – vehicle accident hotspots with respect to the location of ‘trees outside forest’ along roadsides
+25521,Seidler_etal,2015,Observational,Terrestrial,Local,10,north america,United States,Identifying impediments to long-distance mammal migrations
+25523,Seiler,2005,Observational,Terrestrial,Sub-national,,europe,Sweden,Predicting locations of moose-vehicle collisions in Sweden
+25524,Seim_etal,2016,Observational,Terrestrial,Multi-national,,asia,Kyrgyzstan,Climate change increases drought stress of juniper trees in the mountains of central Asia
+25525,Seimon_etal,2013,Observational,Terrestrial,Sub-national,,asia,China,Canine distemper virus: An emerging disease in wild endangered Amur tigers (Panthera tigris altaica)
+25526,Seimon_etal,2015,Observational,Freshwater,Multi-national,,africa,Tanzania,"Assessing the threat of amphibian chytrid fungus in the Albertine Rift: Past, present and future"
+25529,Selkoe_etal,2009,Observational,Marine,Sub-national,0.01,north pacific,Hawaii,"A map of human impacts to a ""pristine"" coral reef ecosystem, the Papah?naumoku?kea Marine National Monument"
+25530,Selman_etal,2013,Experimental,Freshwater,Local,,north america,United States,Effects of human disturbance on the behavior and physiology of an imperiled freshwater turtle
+25531,Selvalakshmi,2014,Observational,Terrestrial,Local,,asia,India,Are the sensitive zones degrading? A modelling approach using GIS and remote sensing
+25535,Semper-Pascual_etal,2020,Observational,Terrestrial,Sub-national,30,south america,Argentina,Using occupancy models to assess the direct and indirect impacts of agricultural expansion on species’ populations
+25539,Senn Helen_etal,2019,Observational,Terrestrial,Sub-national,,europe,United Kingdom,Distinguishing the victim from the threat: SNP?based methods reveal the extent of introgressive hybridization between wildcats and domestic cats in Scotland and inform future in situ and ex situ management options for species restoration
+25542,Serieys_etal,2019,Observational,Terrestrial,Local,,africa,South Africa,Widespread anticoagulant poison exposure in predators in a rapidly growing South African city
+25543,Serra-Varela_etal,2017,Observational,Terrestrial,National,1,europe,Spain,Incorporating exposure to pitch canker disease to support management decisions of Pinus pinaster ait. in the face of Climate change
+25551,Shalders_etal,2018,Observational,Marine,Sub-national,1500,indian ocean,Australia,Potential climate-mediated changes to the distribution and density of pomacentrid reef fishes in south-Western Australia
+25559,Sharma_etal,2018,Observational,Terrestrial,Sub-national,,asia,Nepal,Spatial assessment of the potential impact of infrastructure development on biodiversity conservation in lowland Nepal
+25560,Sharma_etal,2020,Observational,Terrestrial,National,,asia,Nepal,Potential distribution of the critically endangered Chinese pangolin (Manis pentadactyla) in different land covers of Nepal: Implications for conservation
+25565,Shester,2008,Observational,Marine,Local,0.0001,north pacific,Mexico,"Sustainability in small-scale fisheries: An analysis of ecosystem impacts, fishing behavior, and spatial management using participatory research methods"
+25567,Shilling and Waetjen,2015,Observational,Terrestrial,Sub-national,,north america,United States,Wildlife-vehicle collision hotspots at US highway extents: scale and data source effects
+25574,Short_etal,2018,Observational,Marine,Global,,Unknown,Unknown,The use of mosquito nets in fisheries: A global perspective
+25575,Shrestha_etal,2019,Observational,Freshwater,Local,500,asia,India,Identifying and forecasting potential biophysical risk areas within a tropical mangrove ecosystem using multi-sensor data
+25577,Sieber_etal,2013,Observational,Terrestrial,Sub-national,,asia,Russia,Landsat-based mapping of post-Soviet land-use change to assess the effectiveness of the Oksky and Mordovsky protected areas in European Russia
+25582,Sigaud_etal,2020,Observational,Terrestrial,Local,,north america,Canada,Emerging conflict between conservation programmes: when a threatened vertebrate facilitates the dispersal of exotic species in a rare plant community
+25585,Silcock_etal,2019,Observational,Terrestrial,Sub-national,,australasia,Australia,Feral fuchsia eating: Long-term decline of a palatable shrub in grazed rangelands
+25588,Silva_etal,2014,Observational,Terrestrial,Sub-national,,europe,Portugal,A spatially explicit approach to assess the collision risk between birds and overhead power lines: A case study with the little bustard
+25589,Silva_etal,2018,Observational,Terrestrial,Local,0.5,south america,Brazil,"Who let the dogs out? Occurrence, population size and daily activity of domestic dogs in an urban Atlantic Forest reserve"
+25591,Silva_etal,2020,Observational,Terrestrial,Local,200,asia,Thailand,High roadkill rates in the Dong Phayayen-Khao Yai World Heritage Site: conservation implications of a rising threat to wildlife
+25593,Silva-Rodríguez and Sieving,2012,Observational,Terrestrial,Multi-national,,south america,Chile,Domestic dogs shape the landscape-scale distribution of a threatened forest ungulate
+25598,Simon_etal,2019,Observational,Freshwater,Local,,africa,South Africa,Bait Collecting by Subsistence and Recreational Fishers in Knysna Estuary May Impact Management and Conservation
+25600,Singh_etal,2009,Observational,Terrestrial,Local,,asia,India,"Geospatial approach for tiger habitat evaluation and distribution in Corbett Tiger reserve, India"
+25601,Singh_etal,2017,Observational,Terrestrial,Local,,asia,India,"Influence of changes in watershed landuse pattern on the wetland of Sultanpur National Park, Haryana using remote sensing techniques and hydrochemical analysis"
+25607,Sini_etal,2019,Observational,Marine,Sub-national,,mediterranean,Greece,Small-scale coastal fishing shapes the structure of shallow rocky reef fish in the aegean sea
+25614,Skaer,2015,Observational,Terrestrial,Sub-national,,north america,United States,"Spatial Pattern in Invasive Grasses of California: Demography, Competition, and Environmental Alteration"
+25618,Sloan_etal,2018,Observational,Terrestrial,Sub-national,,asia,Indonesia,"Infrastructure development and contested forest governance threaten the Leuser Ecosystem, Indonesia"
+25619,Smeraldo_etal,2020,Observational,Terrestrial,National,,europe,Italy,Modelling risks posed by wind turbines and power lines to soaring birds: the black stork (Ciconia nigra) in Italy as a case study
+25628,Smith Joshua_etal,2020,Observational,Marine,Sub-national,100,south pacific,Australia,Validation of presence-only models for conservation planning and the application to whales in a multiple-use marine park
+25622,Smith_etal,2014,Observational,Terrestrial,Local,30,north america,United States,Prioritizing winter habitat quality for greater sage-grouse in a landscape influenced by energy development
+25625,Smith_etal,2017,Observational,Terrestrial,Local,,north america,United States,Predation risk: A potential mechanism for effects of a wind energy facility on Greater Prairie-Chicken survival
+25629,Smolinski and Calkiewicz,2015,Observational,Marine,Sub-national,,north atlantic,Poland,A fish-based index for assessing the ecological status of Polish transitional and coastal waters
+25630,Snyder_etal,2011,Observational,Terrestrial,Local,,north america,United States,"Spatial variability of an invasive earthworm (Amynthas agrestis) population and potential impacts on soil characteristics and millipedes in the Great Smoky Mountains National Park, USA"
+25633,Soh_etal,2014,Observational,Terrestrial,Local,,asia,China,"Spatial correlates of livestock depredation by Amur tigers in Hunchun, China: Relevance of prey density and implications for protected area management"
+25636,Soiret_etal,2019,Observational,Terrestrial,Local,,africa,Ivory Coast,"The diversity and conservation of mammals in the Dodo Coastal Forest in southwestern Côte d'Ivoire, western Africa: A preliminary study"
+25640,Songer,2006,Observational,Terrestrial,Sub-national,m,asia,Myanmar,Endangered dry deciduous forests of Upper Myanmar (Burma): A multi-scale approach for research and conservation
+25642,Songhurst_etal,2016,Observational,Terrestrial,Local,,africa,Botswana,Finding pathways to human-elephant coexistence: a risky business
+25643,Sonricker_etal,2012,Observational,Freshwater,Global,,Unknown,Unknown,Digital Surveillance: A Novel Approach to Monitoring the Illegal Wildlife Trade
+25645,Soriano_etal,2019,Observational,Freshwater,Local,500,asia,Philippines,"Land Use/Land Cover Change Detection and Urban Sprawl Analysis in the Mount Makiling Forest Reserve Watersheds and Buffer Zone, Philippines"
+25646,Soroye_etal,2020,Observational,Terrestrial,Continental,0.5,europe,Unknown,Climate change contributes to widespread declines among bumble bees across continents
+25651,Sousa_etal,2019,Observational,Marine,Local,,north atlantic,Portugal,Disentangling exploitation of the intertidal grazer Phorcus sauciatus (Gastropoda: Trochidae) in an oceanic archipelago: Implications for conservation
+25654,Spanowicz_etal,2020,Observational,Terrestrial,Multi-national,,north america,Canada,An adaptive plan for prioritizing road sections for fencing to reduce animal mortality
+25656,Spitzen-Van Der_etal,2016,Observational,Terrestrial,Multi-national,,europe,Germany,Expanding distribution of lethal amphibian fungus Batrachochytrium salamandrivorans in Europe
+25664,Stafford_etal,2017,S_Review,Terrestrial,Continental,,south america,Mexico,A Cross-Site Analysis of Neotropical Bird Hunting Profiles
+25671,Steinke and Saito,2013,Observational,Freshwater,Multi-national,,south america,Brazil,Priority wetlands for conservation of waterbird's diversity in the mirim lagoon catchement area (Brazil-Uruguay)
+25674,Steizenmuller_etal,2010,Observational,Marine,Sub-national,,north atlantic,United Kingdom,Towards a spatially explicit risk assessment for marine management: Assessing the vulnerability of fish to aggregate extraction
+25676,Stelzenmuller_etal,2015,Observational,Marine,National,31,north atlantic,Germany,Quantitative environmental risk assessments in the context of marine spatial management: current approaches and some perspectives
+25675,Stelzenmüller_etal,2009,Observational,Marine,Local,50,mediterranean,Spain,Patterns of species and functional diversity around a coastal marine reserve: A fisheries perspective
+25679,Stephens_etal,2016,Observational,Terrestrial,Continental,2500,north america,Unknown,Consistent response of bird populations to climate change on two continents
+25680,Stephenson_etal,2017,Observational,Marine,Local,100,north atlantic,United Kingdom,Spatial and temporal changes in pot-fishing effort and habitat use
+25682,Steven and Castley,2013,Observational,Terrestrial,Global,,Unknown,Unknown,Tourism as a threat to critically endangered and endangered birds: Global patterns and trends in conservation hotspots
+25684,Stewart_etal,2010,Observational,Marine,Continental,1,indian ocean,Unknown,Characterizing fishing effort and spatial extent of coastal fisheries
+25686,Stock_etal,2018,Observational,Marine,Global,5,Unknown,Unknown,Uncertainty analysis and robust areas of high and low modeled human impact on the global oceans
+25687,Stock_etal,2018,Observational,Marine,Sub-national,,north pacific,United States,Mapping ecological indicators of human impact with statistical and machine learning methods: Tests on the California coast
+25688,Stoica_etal,2017,Observational,Terrestrial,Local,0.5,europe,Romania,"A case study in the Moldavian Central Plateau, Romania - habitat distribution, conservation status and human impact in a protected area"
+W26583,Stoner and Pervushina,2013,Observational,Terrestrial,Multi-national,,asia,India,Reduced to Skin and Bones Revisited: An updated analysis of tiger seizures from 12 Tiger range countries (2000 - 2012).
+25692,Stortini_etal,2015,Observational,Marine,Sub-national,,north atlantic,Canada,A decision-support tool to facilitate discussion of no-take boundaries for Marine Protected Areas during stakeholder consultation processes
+25695,Stroud_etal,2017,Observational,Terrestrial,Local,,north america,Bermuda,Establishment of Anolis sagrei on Bermuda represents a novel ecological threat to Critically Endangered Bermuda skinks (Plestiodon longirostris)
+25696,Strubbe_etal,2010,Observational,Terrestrial,National,5,europe,Belgium,Assessing the potential impact of invasive ring-necked parakeets Psittacula krameri on native nuthatches Sitta europeae in Belgium
+25697,Struebig_etal,2018,Observational,Terrestrial,Sub-national,,asia,Indonesia,Addressing human-tiger conflict using socio-ecological information on tolerance and risk
+25709,Swan_etal,2017,Observational,Freshwater,Sub-national,,south america,Brazil,Expert elicitation as a method for exploring illegal harvest and trade of wild meat over large spatial scales
+25711,Swartz_etal,2010,Observational,Marine,Global,0.5,Unknown,Unknown,The spatial expansion and ecological footprint of fisheries (1950 to present)
+W26581,Sylvia_etal,2019,Observational,Marine,Global,,Unknown,Unknown,Status of electronic collection and reporting of key information in major fisheries
+25712,Symes_etal,2018,Observational,Terrestrial,Sub-national,,asia,Indonesia,Combined impacts of deforestation and wildlife trade on tropical biodiversity are severely underestimated
+25713,Syphard_etal,2007,Observational,Terrestrial,Sub-national,1,north america,United States,Human influence on California fire regimes
+25714,Syphard_etal,2009,Observational,Terrestrial,Multi-national,225,mediterranean,Spain,Conservation Threats Due to Human-Caused Increases in Fire Frequency in Mediterranean-Climate Ecosystems
+25716,Syxaiyakhamthor_etal,2019,Observational,Terrestrial,Local,1,asia,Laos,Identifying priority areas for the conservation of the Critically Endangered northern white-cheeked gibbon Nomascus leucogenys in northern Lao
+25717,Szabo_etal,2009,Observational,Terrestrial,Sub-national,0.5,australasia,Australia,Predicting avian distributions to evaluate spatiotemporal overlap with locust control operations in eastern Australia
+25724,Talukdar_etal,2020,Observational,Terrestrial,Local,30,asia,India,"Assessment of forest health status using a forest fragmentation approach: a study in Patharia Hills Reserve Forest, northeast India"
+25726,Tamario_etal,2019,Observational,Freshwater,Sub-national,,europe,Sweden,Coastal river connectivity and the distribution of ascending juvenile European eel (Anguilla anguilla L.): Implications for conservation strategies regarding fish-passage solutions
+25732,Tancell_etal,2016,Observational,Marine,National,,southern ocean,South Georgia and the South Sandwich Islands,Marine spatial planning for the conservation of albatrosses and large petrels breeding at South Georgia
+25734,Tapia-Armijos_etal,2017,Observational,Terrestrial,Sub-national,100,south america,Ecuador,Spatio-temporal analysis of the human footprint in South Ecuador: Influence of human pressure on ecosystems and effectiveness of protected areas
+25737,Tarrant_etal,2013,Observational,Freshwater,National,,africa,South Africa,Spatial Assessment of Amphibian Chytrid Fungus (Batrachochytrium dendrobatidis) in South Africa Confirms Endemic and Widespread Infection
+25740,Taylor_etal,2018,Observational,Freshwater,Sub-national,,north america,United States,Incorporating fragmentation and non-native species into distribution models to inform fluvial fish conservation
+25745,Tello_etal,2020,Observational,Terrestrial,Sub-national,100,europe,Spain,The loss of landscape ecological functionality in the barcelona province (1956-2009): Could land-use history involve a legacy for current biodiversity?
+25751,Thapa_etal,2017,Observational,Terrestrial,Local,5,asia,Nepal,"Combined land cover changes and habitat occupancy to understand corridor status of Laljhadi-Mohana wildlife corridor, Nepal"
+25753,Thaxter_etal,2019,Observational,Terrestrial,Multi-national,400,europe,United Kingdom,Avian vulnerability to wind farm collision through the year: Insights from lesser black-backed gulls (Larus fuscus) tracked from multiple breeding colonies
+25754,Thellmann_etal,2018,Observational,Terrestrial,Local,30,asia,China,Tipping points in the supply of ecosystem services of a mountainous watershed in Southeast Asia
+25755,Theodorakis_etal,2017,Observational,Terrestrial,Local,,north america,United States,Effects of Military activity and habitat quality on DNA damage and oxidative stress in the largest population of the Federally threatened gopher tortoise
+25757,Thiault_etal,2020,Observational,Marine,Sub-national,50,south pacific,Australia,Predicting poaching risk in marine protected areas for improved patrol efficiency
+25761,Thiebot_etal,2014,Observational,Marine,Multi-national,,indian ocean,Australia,Stage-dependent distribution of the Critically Endangered Amsterdam albatross in relation to Economic Exclusive Zones
+25766,Thonfeld_etal,2020,Observational,Freshwater,Sub-national,30,africa,Tanzania,"The impact of anthropogenic land use change on the protected areas of the Kilombero catchment, Tanzania"
+25767,Thongmanivong_etal,2005,Observational,Terrestrial,Local,,asia,Laos,"Resource use dynamics and land-cover change in Ang Nhai Village and Phou Phanang National Reserve Forest, Lao PDR"
+25781,Tingley_etal,2019,Observational,Terrestrial,National,,australasia,Australia,Geographic and taxonomic patterns of extinction risk in Australian squamates
+25784,To_etal,2017,Observational,Terrestrial,Multi-national,,africa,Benin,Protection status and national socio-economic context shape land conversion in and around a key transboundary protected area complex in West Africa
+25796,Tolotti_etal,2015,Observational,Marine,Multi-national,degrees,south atlantic,Brazil,Vulnerability of the oceanic whitetip shark to pelagic longline fisheries
+25798,Topp-Jorgensen_etal,2009,Observational,Terrestrial,Local,,africa,Tanzania,"Relative densities of mammals in response to different levels of bushmeat hunting in the Udzungwa Mountains, Tanzania"
+25802,Tovar_etal,2012,Observational,Terrestrial,Local,,south america,Peru,Recent Changes in Patch Characteristics and Plant Communities in the Jalca Grasslands of the Peruvian Andes
+25803,Tracy_etal,2019,Observational,Terrestrial,Multi-national,100,north america,United States,Modeling fall migration pathways and spatially identifying potential migratory hazards for the eastern monarch butterfly
+25806,Trebilco_etal,2011,Observational,Marine,Global,5,Unknown,Unknown,Mapping species richness and human impact drivers to inform global pelagic conservation prioritisation
+25805,Trebilco_etal,2008,Observational,Marine,Sub-national,50,south pacific,Macquarie Island,At sea movement of Macquarie Island giant petrels: Relationships with marine protected areas and Regional Fisheries Management Organisations
+25808,Treves_etal,2006,Observational,Terrestrial,Multi-national,,africa,Uganda,"A simple, cost-effective method for involving stakeholders in spatial assessments of threats to biodiversity"
+25813,Trew_etal,2019,Observational,Marine,National,16,north atlantic,Equatorial Guinea,Using Cumulative Impact Mapping to Prioritize Marine Conservation Efforts in Equatorial Guinea
+25820,Trochine_etal,2018,Observational,Freshwater,Continental,,europe,Unknown,Non-native Fish Occurrence and Biomass in 1943 Western Palearctic Lakes and Reservoirs and their Abiotic and Biotic Correlates
+25821,Troia and Mcmanamay,2020,Observational,Freshwater,Sub-national,,north america,United States,Biogeographic classification of streams using fish community– and trait–environment relationships
+25824,Troy,2013,Observational,Terrestrial,Local,,north america,United States,"Studies of artificial light, seabird fallout, and habitat suitability concerning newell's shearwater and Hawaiian petrel conservation"
+25826,Trull_etal,2017,Observational,Terrestrial,Global,,Unknown,Unknown,Patterns and biases of climate change threats in the IUCN Red List
+25830,Tucker_etal,2018,Observational,Terrestrial,Global,1,Unknown,Unknown,Moving in the Anthropocene: Global reductions in terrestrial mammalian movements
+25833,Tulloch_etal,2020,Observational,Marine,Global,km2,Unknown,Unknown,Linking threat maps with management to guide conservation investment
+25832,Tulloch_etal,2020,Observational,Marine,National,0.5,south pacific,Australia,Long-term trends and a risk analysis of cetacean entanglements and bycatch in fisheries gear in Australian waters
+25837,Tursi_etal,2018,Observational,Marine,Local,,mediterranean,Italy,Mega-litter and remediation: the case of Mar Piccolo of Taranto (Ionian Sea)
+25838,Twumasi,2006,Observational,Freshwater,Sub-national,30,africa,Nigeria,Management of watersheds with remote sensing and gis: A case study of River Delta Region in Nigerianiger
+25846,Underwood_etal,2011,Observational,Terrestrial,Sub-national,m,north america,United States,Incorporating biodiversity conservation and recreational wildlife values into smart growth land use planning
+W26577,Uryu_etal,2008,Observational,Terrestrial,Sub-national,1000,asia,Indonesia,"Deforestation, Forest Degradation, Biodiversity Loss and CO2 Emissions in Riau, Sumatra, Indonesia"
+25850,Vacchiano_etal,2018,Observational,Terrestrial,Local,1,europe,Italy,Modeling anthropogenic and natural fire ignitions in an inner-alpine valley
+25856,Valliere,2016,Observational,Terrestrial,Local,1,north america,United States,"Ecological Impacts of Nitrogen Deposition, Drought and Nonnative Plant Invasion on Coastal Sage Scrub of the Santa Monica Mountains"
+25857,Valliere_etal,2020,Observational,Terrestrial,Local,km2,north america,United States,Declines in native forb richness of an imperiled plant community across an anthropogenic nitrogen deposition gradient
+25865,Van Den_etal,2018,Observational,Terrestrial,Local,,south america,Suriname,Sustainability issues of commercial non-timber forest product extraction in West Suriname
+25866,Van Der_etal,2018,Observational,Marine,Multi-national,,north atlantic,United Kingdom,North Sea demersal fisheries prefer specific benthic habitats
+25874,Van_etal,2018,Observational,Terrestrial,Continental,,south america,Unknown,Tree genetic resources at risk in South America: A spatial threat assessment to prioritize populations for conservation
+25858,Van_etal,2015,Observational,Terrestrial,Multi-national,arc-minutes,africa,Benin,Prioritizing West African medicinal plants for conservation and sustainable extraction studies based on market surveys and species distribution models
+25862,Van_etal,2015,Observational,Terrestrial,Multi-national,900,africa,Kenya,Environmental gap analysis to prioritize conservation efforts in eastern Africa
+25870,Van_etal,2017,Experimental,Terrestrial,Local,,north america,United States,Evaluating efficacy of fence markers in reducing greater sage-grouse collisions with fencing
+25875,Vanderlaan_etal,2009,Observational,Marine,Sub-national,5,north atlantic,United States,Probability and mitigation of vessel encounters with North Atlantic right whales
+25877,Vanderpost,2007,Observational,Terrestrial,Local,,africa,Botswana,"Protected Areas in Ngamiland, Botswana: Investigating Options for Conservation-Development Through Human Footprint Mapping"
+25878,Vangansbeke_etal,2017,Observational,Terrestrial,Local,,europe,Belgium,Spatially combining wood production and recreation with biodiversity conservation
+25879,Vanthomme_etal,2017,Observational,Terrestrial,Local,25,africa,Gabon,Antipoaching standards in onshore hydrocarbon concessions drawn from a Central African case study
+25880,Vardarman_etal,2018,Observational,Terrestrial,Local,,europe,Czech Republic,The role of protected area zoning in invasive plant management
+25884,Vasapollo_etal,2019,Observational,Marine,Sub-national,,mediterranean,Italy,Bottom trawl catch comparison in the Mediterranean Sea: Flexible Turtle Excluder Device (TED) vs traditional gear
+25888,Vasilakis_etal,2016,Observational,Terrestrial,Multi-national,,europe,Bulgaria,Reconciling endangered species conservation with wind farm development: Cinereous vultures (Aegypius monachus) in south-eastern Europe
+25889,Vasilakis_etal,2017,Observational,Terrestrial,Multi-national,,europe,Bulgaria,A balanced solution to the cumulative threat of industrialized wind farm development on cinereous vultures (Aegypius monachus) in south-eastern Europe
+25891,Vasyliuk_etal,2015,Observational,Terrestrial,National,,europe,Ukraine,A review of major impact factors of hostilities influencing biodiversity in the Eastern Ukraine (Modeled On Selected Animal Species)
+25892,Veach_etal,2017,Observational,Terrestrial,Global,1,Unknown,Unknown,"Threats from urban expansion, agricultural transformation and forest loss on global conservation priority areas"
+25894,Velado-Alonso_etal,2020,Observational,Terrestrial,National,100,europe,Spain,Relationships between the distribution of wildlife and livestock diversity
+25896,Velho_etal,2012,S_Review,Terrestrial,National,,asia,India,"Hunting: A serious and understudied threat in India, a globally significant conservation region"
+25901,Vendramin_etal,2013,Observational,Marine,Sub-national,,mediterranean,Italy,Viral Encephalopathy and Retinopathy in groupers (Epinephelus spp.) in southern Italy: a threat for wild endangered species?
+25903,Venegas-Li_etal,2019,Observational,Marine,Global,0.5,Unknown,Unknown,Global assessment of marine biodiversity potentially threatened by offshore hydrocarbon activities
+25904,Venkataraman_etal,2002,Observational,Terrestrial,Sub-national,,asia,India,Conservation of a flagship species: Prioritizing Asian Elephant (Elephas maximus) conservation units in southern India
+25908,Vergara-Tabares_etal,2020,Observational,Terrestrial,Continental,0.5,africa,Unknown,Global trends of habitat destruction and consequences for parrot conservation
+25911,Verones_etal,2017,Observational,Terrestrial,Global,12100,Unknown,Unknown,Biodiversity impacts from water consumption on a global scale for use in life cycle assessment
+25912,Versluijs_etal,2020,Experimental,Terrestrial,Sub-national,,europe,Sweden,Comparing the effects of even-aged thinning and selective felling on boreal forest birds
+25913,Verutes_etal,2020,Observational,Marine,Multi-national,,south china sea,Malaysia,Using GIS and stakeholder involvement to innovate marine mammal bycatch risk assessment in data-limited fisheries
+25925,Vimal_etal,2012,Observational,Terrestrial,Sub-national,100,europe,France,Exploring spatial patterns of vulnerability for diverse biodiversity descriptors in regional conservation planning
+25926,Vinitpornsawar,2013,Observational,Terrestrial,Local,1,asia,Thailand,"Population and spatial ecology of tigers and leopards relative to prey availability and human activity in thung yai naresuan (east) wildlife sanctuary, Thailand"
+25930,Visintin_etal,2018,Observational,Terrestrial,Sub-national,1,australasia,Australia,Managing the timing and speed of vehicles reduces wildlife-transport collision risk
+25933,Vogel,2007,Experimental,Freshwater,Sub-national,,north america,United States,"The decline of Fowler's toad (<i>Bufo fowleri</i>) in southern Louisiana: Molecular genetics, field experiments and landscape studies"
+25934,Vojar_etal,2017,Observational,Freshwater,Multi-national,,europe,Montenegro,"Distribution, prevalence, and amphibian hosts of Batrachochytrium dendrobatidis in the Balkans"
+25936,Vörösmarty_etal,2010,Observational,Freshwater,Global,0.5,Unknown,Unknown,Global threats to human water security and river biodiversity
+25942,Wakeel_etal,2005,Observational,Terrestrial,Local,,asia,India,"Forest management and land use/cover changes in a typical micro watershed in the mid elevation zone of Central Himalaya, India"
+25944,Walentowitz_etal,2019,Observational,Terrestrial,Local,500,europe,Spain,Graminoid invasion in an insular endemism hotspot and its protected areas
+25948,Walker_etal,2020,Observational,Terrestrial,Local,,north america,United States,"Quantifying habitat loss and modification from recent expansion of energy infrastructure in an isolated, peripheral greater sage-grouse population"
+25952,Wallace_etal,2011,Observational,Marine,Global,,Unknown,Unknown,Global conservation priorities for Marine turtles
+25953,Wallace_etal,2013,Observational,Marine,Global,,Unknown,Unknown,Impacts of fisheries bycatch on marine turtle populations worldwide: Toward conservation and research priorities
+25957,Walston and Hartmann,2018,Observational,Terrestrial,Sub-national,90,north america,United States,Development of a landscape integrity model framework to support regional conservation planning
+25959,Waltham and Sheaves,2015,Observational,Marine,Sub-national,,south pacific,Australia,Expanding coastal urban and industrial seascape in the Great Barrier Reef World Heritage Area: Critical need for coordinated planning and policy
+25960,Wamelink_etal,2013,Observational,Terrestrial,National,250,europe,Netherlands,Considerable environmental bottlenecks for species listed in the Habitats and Birds Directives in the Netherlands
+25970,Wang_etal,2017,Observational,Terrestrial,National,2.5,asia,China,The spatial distribution of threats to plant species with extremely small populations
+25973,Wanghe_etal,2020,Observational,Terrestrial,Sub-national,,asia,China,Spatial coincidence between mining activities and protected areas of giant panda habitat: The geographic overlaps and implications for conservation
+25978,Wasser_etal,2008,Observational,Terrestrial,Multi-national,,africa,Angola,Combating the illegal trade in African elephant ivory with DNA forensics
+25980,Watson_etal,2015,Observational,Terrestrial,Sub-national,,africa,Zambia,Human encroachment into protected area networks in Zambia: implications for large carnivore conservation
+25986,Weimerskirch_etal,2018,Observational,Marine,Continental,,indian ocean,Unknown,Use of radar detectors to track attendance of albatrosses at fishing vessels
+25988,Weinzettel_etal,2018,Observational,Terrestrial,Global,,Unknown,Unknown,Human footprint in biodiversity hotspots
+25991,Weir_etal,2011,Observational,Marine,Local,,south atlantic,Angola,"West Africa's Atlantic humpback dolphin (Sousa teuszii): Endemic, enigmatic and soon endangered?"
+25997,Wessels_etal,2000,Observational,Terrestrial,Sub-national,15,africa,South Africa,Incorporating land cover information into regional biodiversity assessments in South Africa
+25998,Wessels_etal,2003,Observational,Terrestrial,Sub-national,700,africa,South Africa,Identification of potential conflict areas between land transformation and biodiversity conservation in north-eastern South Africa
+26001,White,2018,Observational,Terrestrial,Sub-national,,south america,Brazil,"Spatiotemporal variation in fire occurrence in the state of Amazonas, Brazil, between 2003 and 2016"
+26002,Whitty,2016,Observational,Marine,Local,,south atlantic,Philippines,"Multi-methods approach to characterizing the magnitude, impact, and spatial risk of Irrawaddy dolphin (Orcaella brevirostris) bycatch in small-scale fisheries in Malampaya Sound, Philippines"
+26006,Wiemeyer_etal,2017,Observational,Terrestrial,Continental,,south america,Unknown,Repeated conservation threats across the Americas: High levels of blood and bone lead in the Andean Condor widen the problem to a continental scale
+26011,Wiley_etal,2011,Observational,Marine,Sub-national,,north atlantic,United States,"Modeling speed restrictions to mitigate lethal collisions between ships and whales in the Stellwagen Bank National Marine Sanctuary, USA"
+26214,Williams,2017,Observational,Marine,Sub-national,1,north pacific,Alaska,Quantifying the Ecological Processes Underlying Collisions Between Large Baleen Whales and Large Ships to Evaluate Risk
+26015,Williams and O'hara,2010,Observational,Marine,Sub-national,25,north pacific,Canada,"Modelling ship strike risk to fin, humpback and killer whales in British Columbia, Canada"
+26017,Williams_etal,2014,Observational,Terrestrial,Continental,,africa,Unknown,Risks to birds traded for African traditional medicine: A quantitative assessment
+26016,Williams_etal,2011,Observational,Marine,Sub-national,25,north pacific,Canada,"Marine mammals and debris in coastal waters of British Columbia, Canada"
+26032,Winchell_etal,2012,Observational,Freshwater,Sub-national,,north america,United States,A GIS-based approach to quantifying pesticide use site proximity to salmonid habitat
+26033,Winchell_etal,2014,Observational,Freshwater,Sub-national,,north america,United States,"Application of an approach for predicting pesticide concentrations in static water bodies using spatially explicit hydrography, landscape, and pesticide use data"
+26036,Winemiller_etal,2016,Observational,Freshwater,Multi-national,,africa,Brazil,"Balancing hydropower and biodiversity in the Amazon, Congo, and Mekong"
+26042,Winters_etal,2017,Observational,Marine,Local,,mediterranean,Israel,"A low cost field-survey method for mapping seagrasses and their potential threats: an example from the northern Gulf of Aqaba, Red Sea"
+26044,Witt and Godley,2007,Observational,Marine,Multi-national,9,north atlantic,United Kingdom,A step towards seascape scale conservation: Using vessel monitoring systems (VMS) to map fishing activity
+26047,Wittig_etal,2007,Observational,Terrestrial,National,,africa,Burkina Faso,A study of climate change and anthropogenic impacts in West Africa
+26049,Woinarski_etal,2018,Observational,Terrestrial,National,,australasia,Australia,How many reptiles are killed by cats in Australia?
+26050,Wolaver_etal,2018,Observational,Terrestrial,Sub-national,1,north america,United States,An approach for evaluating changes in land-use from energy sprawl and other anthropogenic activities with implications for biotic resource management
+W26585,Wong,2019,Observational,Terrestrial,Global,,Unknown,Unknown,Skin and Bones Unresolved: An Analysis of Tiger Seizures from 2000–2018.
+26053,Wong_etal,2018,Observational,Marine,Sub-national,,arctic ocean,Canada,"Seasonal vessel activity risk to seabirds in waters off Baffin Island, Canada"
+26054,Woodcock_etal,2013,Observational,Terrestrial,Sub-national,,asia,Malaysia,Impacts of Intensive Logging on the Trophic Organisation of Ant Communities in a Biodiversity Hotspot
+26057,Wraith and Pickering,2019,Observational,Terrestrial,National,,australasia,Australia,A continental scale analysis of threats to orchids
+26060,Wu,2016,Observational,Terrestrial,National,0.5,asia,China,Detecting and Attributing the Effects of Climate Change on the Distributions of Snake Species Over the Past 50 Years
+26063,Wu_etal,2020,Observational,Terrestrial,Multi-national,30,asia,China,Ecological environment assessment for Greater Mekong Subregion based on Pressure-State-Response framework by remote sensing
+W26574,Wwf,2016,Observational,Terrestrial,Multi-national,,asia,Myanmar,The Road Ahead: Protecting Tigers from Asia's Infrastructure Development Boom
+W26575,Wwf,2017,Observational,Terrestrial,Sub-national,,asia,Indonesia,Using Public Data platforms to assess deforestation risks within jurisdictions
+W26580,Wwf,2016,Observational,Terrestrial,Local,,north america,Mexico,Forest Degradation in the Core Zone of the Monarch Butterfly Biosphere Reserve 2015-2016
+W26578,Wwf,2014,Observational,Marine,National,,north pacific,Russia,Illegal Russian Crab: An Investigation of Trade Flow
+W26576,Wwf-Indonesia,2013,Observational,Terrestrial,Local,,asia,Indonesia,"Palming Off a National Park. Tracking Illegal oil Palm Fruit in Riau, Sumatra"
+26067,Wyatt_etal,2017,Observational,Marine,Sub-national,1,north atlantic,United States,Habitat risk assessment for regional ocean planning in the U.S. Northeast and Mid-Atlantic
+26068,Xavier Da_etal,2018,Observational,Terrestrial,Local,,south america,Argentina,"Effectiveness of Protected Areas for biodiversity conservation: Mammal occupancy patterns in the Iguaçu National Park, Brazil"
+26074,Xofis and Poirazidis,2018,Observational,Terrestrial,Local,0.5,europe,Greece,Combining different spatio-temporal resolution images to depict landscape dynamics and guide wildlife management
+26076,Xu_etal,2016,Observational,Terrestrial,National,0.5,asia,China,"The exposure, sensitivity and vulnerability of natural vegetation in China to climate thermal variability (1901-2013): An indicator-based approach"
+26078,Xu_etal,2019,Observational,Terrestrial,Sub-national,30,asia,China,Impacts of Land-Use Change on Habitat Quality during 1985-2015 in the Taihu Lake Basin
+26080,Yackulic_etal,2011,Observational,Terrestrial,Continental,2500,africa,Unknown,Anthropogenic and environmental drivers of modern range loss in large mammals
+26081,Yadav_etal,2020,Observational,Terrestrial,Local,m,asia,India,Susceptibility assessment of human–leopard conflict in Aravalli landscape of Haryana using geospatial techniques
+26084,Yang_etal,2017,Observational,Freshwater,Local,,asia,China,The joint effect of tidal barrier construction and freshwater releases on the macrobenthos community in the northern Yellow River Delta (China)
+26086,Yang_etal,2019,Observational,Terrestrial,Sub-national,30,asia,China,"Prioritizing Spatially Aggregated Cost-Effective Sites in Natural Reserves to Mitigate Human-Induced Threats: A Case Study of the Qinghai Plateau, China"
+26089,Ye_etal,2015,Observational,Terrestrial,Sub-national,30,asia,China,Assessing local and surrounding threats to the protected area network in a biodiversity hotspot: The Hengduan Mountains of Southwest China
+26090,Yee and Barron,2010,Observational,Marine,Global,,Unknown,Unknown,Predicting coral bleaching in response to environmental stressors using 8 years of global-scale data
+26092,Yin_etal,2020,Observational,Terrestrial,Sub-national,1,asia,China,Spatio-temporal analysis of the human footprint in the Hengduan Mountain region: Assessing the effectiveness of nature reserves in reducing human impacts
+26094,Young_etal,2011,Observational,Terrestrial,Local,,north america,United States,Geographic profiling to assess the risk of rare plant poaching in natural areas
+26096,Yu_etal,2001,Observational,Freshwater,Sub-national,,asia,China,Planning for Wetland Protection and Restoration in the Yellow River Delta in China
+26098,Yu_etal,2020,Observational,Freshwater,Multi-national,1,asia,Uzbekistan,Exploring variability in landscape ecological risk and quantifying its driving factors in the amu darya delta
+26102,Yumnam_etal,2014,Observational,Terrestrial,Sub-national,100,asia,India,Prioritizing tiger conservation through landscape genetics and habitat linkages
+26103,Zacharias and Gregr,2005,Observational,Marine,Sub-national,,north pacific,Canada,Sensitivity and vulnerability in marine environments: An approach to identifying vulnerable marine areas
+26104,Zafra-Calvo_etal,2010,Observational,Terrestrial,Local,1,africa,Equatorial Guinea,Discerning the impact of human-mediated factors on biodiversity using bioclimatic envelope models and partial regression techniques
+26111,Zampiglia_etal,2013,Observational,Freshwater,National,,europe,Italy,Geographic distribution of the chytrid pathogen Batrachochytrium dendrobatidis among mountain amphibians along the Italian peninsula
+26112,Zapata-Ríos_etal,2009,Observational,Terrestrial,Local,,south america,Ecuador,Mammal hunting by the Shuar of the Ecuadorian Amazon: Is it sustainable?
+26117,Zhai_etal,2012,Observational,Terrestrial,Local,10,asia,China,Rubber and pulp plantations represent a double threat to Hainan's natural tropical forests
+26127,Zhang and Vincent,2019,Observational,Marine,Global,1,Unknown,Unknown,Using cumulative human-impact models to reveal global threat patterns for seahorses
+26120,Zhang_etal,2007,Observational,Terrestrial,Local,30,asia,China,"Evaluation of habitat fragmentation of giant panda (Ailuropoda melanoleuca) on the north slopes of Daxiangling Mountains, Sichuan province, China"
+26131,Zhao_etal,2020,Observational,Terrestrial,Sub-national,,asia,China,Quantifying the heavy metal risks from anthropogenic contributions in Sichuan panda (Ailuropoda melanoleuca melanoleuca) habitat
+26135,Zhu_etal,2019,Observational,Terrestrial,National,1,asia,China,The impacts of human activities on ecosystems within China's nature reserves
+26137,Ziegler_etal,2016,Observational,Terrestrial,Multi-national,1,africa,Central African Republic,Mapping Bushmeat Hunting Pressure in Central Africa
+26140,Zimkus_etal,2020,S_Review,Freshwater,Continental,1,africa,Unknown,Chytrid pathogen (batrachochytrium dendrobatidis) in african amphibians: A continental analysis of occurrences and modeling of its potential distribution
+26141,Zingraff-Hamed_etal,2018,Observational,Freshwater,Local,,europe,Germany,Model-based evaluation of urban river restoration: Conflicts between sensitive fish species and recreational users
+26142,Zomer_etal,2014,Observational,Terrestrial,Multi-national,1,asia,China,"Environmental stratification to model climate change impacts on biodiversity and rubber production in Xishuangbanna, Yunnan, China"
+26145,Žydelis_etal,2009,S_Review,Marine,Multi-national,,north atlantic,United Kingdom,Bycatch in gillnet fisheries - An overlooked threat to waterbird populations

--- a/merge_ridley_title.py
+++ b/merge_ridley_title.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+BIB_PATH = r"data\Ridley_bibliography.csv"
+PROCESSED_PATH = r"data\processed\ridley_articles_dashboard.csv"
+
+bib = pd.read_csv(BIB_PATH)
+rid = pd.read_csv(PROCESSED_PATH)
+
+# Clean column names (handles weird spaces like "Year ")
+bib.columns = bib.columns.str.strip()
+rid.columns = rid.columns.str.strip()
+
+# Keep only ArticleID + Title from bibliography
+bib_small = bib[["ArticleID", "Title"]].drop_duplicates(subset=["ArticleID"])
+
+# Merge Title into processed ridley
+out = rid.merge(bib_small, on="ArticleID", how="left")
+
+print("Title added:", "Title" in out.columns)
+print("Missing Title %:", out["Title"].isna().mean())
+print(out[["ArticleID", "Title"]].head(5))
+
+# Save back to the processed file
+out.to_csv(PROCESSED_PATH, index=False)
+print("Saved:", PROCESSED_PATH)


### PR DESCRIPTION
I added the Title column to ridley_articles_dashboard.csv by merging it from Ridley_bibliography.csv using ArticleID.

Now the processed Ridley dataset includes the article titles, so filters and search can use the same dataset consistently.

I also added a small script (merge_ridley_title.py) to perform the merge and verify that no titles are missing.