### PR TITLE
Make layout components use the same dataset

### DIFF
--- a/layout/components/search_and_filters.py
+++ b/layout/components/search_and_filters.py
@@ -1,6 +1,7 @@
 import dash_bootstrap_components as dbc
 from dash import dcc
-from utils.data_loader import df_grossi, get_threat_categories
+from utils.data_loader import df_ridley, get_threat_categories
+
 
 # SEARCH BARS
 
@@ -36,7 +37,7 @@ def create_continent_filter():
         id='continent-filter',
         options=[{'label': 'All', 'value': 'all'}] + 
                 [{'label': cont.title(), 'value': cont} 
-                    for cont in sorted(df_grossi['Continent_Ocean'].dropna().unique())],
+                    for cont in sorted(df_ridley['Continent_Ocean'].dropna().unique())],
         value='all',
         clearable=False,
         className="mb-3"


### PR DESCRIPTION
Summary
- Updated layout/components/search_and_filters.py to use df_ridley instead of df_grossi
- Ensured the continent filter options are built from the same dataset as the rest of the dashboard flow

Verification
- Confirmed the continent dropdown now uses Ridley values
- Dashboard loads correctly after the change
