### PR TITLE
Unify dashboard filtering across map charts and table

### DIFF
--- a/callbacks/callbacks.py
+++ b/callbacks/callbacks.py
@@ -28,33 +28,49 @@ def register_callbacks(app):
             Output('threat-chart', 'figure'),
             Output('study-design-chart', 'figure'),
             Output('wordcloud-chart', 'figure'),
+            Output('article_table', 'data'),
         ],
         [
-            Input('apply-filters-btn', 'n_clicks')
-        ],
-        [
+            Input('apply-filters-btn', 'n_clicks'),
             Input('continent-filter', 'value'),
             Input('ecoregion-filter', 'value'),
             Input('study-design-filter', 'value'),
-            Input('threat-category-filter', 'value')
+            Input('threat-category-filter', 'value'),
+            Input('year-range-slider', 'value'),
+            Input('searchbar', 'value')
         ],
         prevent_initial_call=False
     )
-    def update_dashboard(n_clicks, continent, ecoregions, study_designs, threat_category):
+    def update_dashboard(n_clicks, continent, ecoregions, study_designs, threat_category, year_range, search_value):
         """
         Main callback to filter data and update all visualizations.
         Triggered by Apply Filters button click.
         """
 
+        filtered_df = df_ridley.copy()
 
         # Apply filters
         filtered_df = filter_data(
-            df=df_ridley,
+            df=filtered_df,
             continent=continent,
             ecoregions=ecoregions,
             study_designs=study_designs,
             threat_category=threat_category
         )
+
+        # Filter by year range
+        if year_range:
+            filtered_df = filtered_df[
+                (filtered_df['Year'] >= year_range[0]) &
+                (filtered_df['Year'] <= year_range[1])
+            ]
+
+        # Filter by search text
+        if search_value:
+            filtered_df = filtered_df[filtered_df.apply(
+                lambda row: row.astype(str).str.contains(search_value, case=False, na=False).any(),
+                axis=1
+            )]
         
         # Create result counter text
         total_articles = len(df_ridley)
@@ -66,9 +82,11 @@ def register_callbacks(app):
         map_fig = create_world_map(filtered_df)
         threat_fig = create_threat_distribution_chart(filtered_df)
         design_fig = create_study_design_chart(filtered_df)
-        wordcloud_fig = create_wordcloud_chart()
+        wordcloud_fig = create_wordcloud_chart(filtered_df)
+
+        table_df = filtered_df[['Authors', 'Year', 'Title']]
         
-        return counter_text, map_fig, threat_fig, design_fig, wordcloud_fig
+        return counter_text, map_fig, threat_fig, design_fig, wordcloud_fig, table_df.to_dict('records')
     
     @app.callback(
         [
@@ -93,27 +111,3 @@ def register_callbacks(app):
             defaults['threat-category-filter'],
             defaults['year-range-slider'],
         )
-
-    @app.callback(
-        Output('article_table','data'),
-        Input('searchbar','value'),
-        Input('year-range-slider', 'value')
-    )
-    def update_search_bar(search_value, year_range):
-        filtered_df = ridley_bib_table.copy()
-
-        # Filter by year range
-        if year_range:
-            filtered_df = filtered_df[
-                (filtered_df['Year'] >= year_range[0]) &
-                (filtered_df['Year'] <= year_range[1])
-            ]
-
-        # Filter by search text
-        if search_value:
-            filtered_df = filtered_df[filtered_df.apply(
-                lambda row: row.astype(str).str.contains(search_value, case=False).any(),
-                axis=1
-            )]
-
-        return filtered_df.to_dict('records')

--- a/layout/components/charts.py
+++ b/layout/components/charts.py
@@ -191,8 +191,9 @@ def create_wordcloud_chart(filtered_df=None):
     else:
         titles = ' '.join(filtered_df['Title'].dropna().astype(str).tolist())
 
+    fig = go.Figure()
+
     if not titles.strip():
-        fig = go.Figure()
         fig.update_layout(
             title='Article Keywords Wordcloud',
             height=300,
@@ -202,20 +203,23 @@ def create_wordcloud_chart(filtered_df=None):
         )
         return fig
 
-    wc = WordCloud(width=500, height=260, background_color='white').generate(titles)
+    try:
+        wc = WordCloud(width=500, height=260, background_color='white').generate(titles)
 
-    buf = io.BytesIO()
-    wc.to_image().save(buf, format='PNG')
-    buf.seek(0)
-    img_b64 = base64.b64encode(buf.read()).decode()
+        buf = io.BytesIO()
+        wc.to_image().save(buf, format='PNG')
+        buf.seek(0)
+        img_b64 = base64.b64encode(buf.read()).decode()
 
-    fig = go.Figure()
-    fig.add_layout_image(dict(
-        source=f'data:image/png;base64,{img_b64}',
-        xref='paper', yref='paper',
-        x=0, y=1, sizex=1, sizey=1,
-        sizing='stretch', layer='below'
-    ))
+        fig.add_layout_image(dict(
+            source=f'data:image/png;base64,{img_b64}',
+            xref='paper', yref='paper',
+            x=0, y=1, sizex=1, sizey=1,
+            sizing='stretch', layer='below'
+        ))
+    except BaseException:
+        pass
+
     fig.update_layout(
         title='Article Keywords Wordcloud',
         height=300,

--- a/layout/components/charts.py
+++ b/layout/components/charts.py
@@ -183,10 +183,25 @@ def create_study_design_chart(df):
 # WORDCLOUD
 
 
-def create_wordcloud_chart():
-    """Generate a wordcloud from Ridley bibliography article titles."""
+def create_wordcloud_chart(filtered_df=None):
+    """Generate a wordcloud from article titles."""
 
-    titles = ' '.join(ridley_bib_table['Title'].dropna().tolist())
+    if filtered_df is None:
+        titles = ' '.join(ridley_bib_table['Title'].dropna().astype(str).tolist())
+    else:
+        titles = ' '.join(filtered_df['Title'].dropna().astype(str).tolist())
+
+    if not titles.strip():
+        fig = go.Figure()
+        fig.update_layout(
+            title='Article Keywords Wordcloud',
+            height=300,
+            margin=dict(l=0, r=0, t=40, b=0),
+            xaxis=dict(visible=False, range=[0, 1]),
+            yaxis=dict(visible=False, range=[0, 1])
+        )
+        return fig
+
     wc = WordCloud(width=500, height=260, background_color='white').generate(titles)
 
     buf = io.BytesIO()


### PR DESCRIPTION
### Changes made
- Unified dashboard updates for:
  - result counter
  - world map
  - threat chart
  - study design chart
  - wordcloud
  - article table
- Updated the article table to use the same filtered `df_ridley` dataset
- Updated the wordcloud function so it supports filtered callback updates and initial layout load

### Result
- Search now updates charts, map, wordcloud, and article table
- Filters now update charts, map, wordcloud, and article table
- Year range now updates charts, map, wordcloud, and article table