### PR TITLE
Fix Windows invoke start and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,20 @@ Windows:
 python -m venv venv
 ```
 
-3. open virtual environment:
+3. Open virtual environment:
 
 Linux:
+
 ```bash
 source venv/bin/activate
 ```
-Windows:
-```bash
-venv\Scripts\activate
+
+Windows (PowerShell):
+
+```powershell
+.\venv\Scripts\Activate.ps1
 ```
+
 4. Install Python dependencies
 
 ```bash
@@ -51,9 +55,11 @@ pip install -r requirements.txt
 
 ## Setting up SQLite database and data cleaning
 
-Go to the set_up folder. First you may check that it is using the excel file of your choice and run the data_exploration_excel.ipynb file to test it.
+Go to the `set_up_and_data_exploration` folder. First, check that the notebook is using the Excel file of your choice and run `data_exploration_excel.ipynb` to inspect the data.
 
-After this carefully go through and run the set_up ipynb file to set up SQLite database for your data and make sure you are converting the correct file!
+After this, carefully go through and run `set_up.ipynb` to set up the SQLite database for your data. Make sure you are converting the correct file.
+
+Additional CSV setup scripts are located in the `set_up_csv` folder.
 
 ## Running the program
 
@@ -61,6 +67,12 @@ After this carefully go through and run the set_up ipynb file to set up SQLite d
 
 ```bash
 invoke start
+```
+
+On Windows, if `invoke` is not recognized, use:
+
+```bash
+python -m invoke start
 ```
 
 ## Running tests
@@ -75,6 +87,8 @@ Make sure Chromedriver or Geckodriver (Firefox) is installed!!
 
 
 (make sure you have opened the virtual environment, it should say venv in the corner)
+
+On Windows, if `invoke` is not recognized, replace `invoke` with `python -m invoke` in the commands below.
 
 1. Run non-ui tests on terminal:
 

--- a/app.py
+++ b/app.py
@@ -19,5 +19,5 @@ register_callbacks(app)
 # Run server
 if __name__ == "__main__":
     print("Starting Dashboard...")
-    print("Open browser at: http://127.0.0.1:8050")
-    app.run(debug=DEBUG_MODE)
+    print("Open browser at: http://127.0.0.1:8768")
+    app.run(debug=DEBUG_MODE, host="0.0.0.0", port=8768)

--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ with open(THREAT_CODES_JSON, 'r', encoding='utf-8') as f:
 
 # App settings
 APP_TITLE = "Biodiversity Interactive Dashboard"
-DEBUG_MODE = True
+DEBUG_MODE = False # this should be False in production, set to True for development to enable hot-reloading and debug info
 
 # Wordcloud settings — modify these to customise the word cloud without touching chart code
 WORDCLOUD_MAX_WORDS = 80

--- a/tasks.py
+++ b/tasks.py
@@ -1,12 +1,12 @@
 from invoke import task
 from subprocess import call
-from sys import platform
+from sys import platform, executable
 
 USE_PTY = platform != "win32"
 
 @task
 def start(ctx):
-    ctx.run("python3 app.py", pty=USE_PTY)
+    ctx.run(f"{executable} app.py", pty=USE_PTY)
 
 @task
 def test(ctx):


### PR DESCRIPTION
## Summary
- Fixed `invoke start` on Windows by using the active Python executable instead of `python3`
- Updated README setup folder instructions
- Added Windows notes for running invoke commands

## Verified on Windows
- `python -m invoke start` starts the dashboard
- `python -m invoke test` passes: 33 tests passed
- `python -m invoke coverage-report` generates the HTML report